### PR TITLE
Introduce kubernetes artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:latest AS build
+ENV BUILD_PATH="github.com/avinetworks/avi_k8s_controller"
+RUN mkdir -p $GOPATH/src/$BUILD_PATH
+COPY avi_k8s_controller $GOPATH/src/$BUILD_PATH
+WORKDIR $BUILD_PATH
+RUN go get $BUILD_PATH
+RUN GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -o $GOPATH/bin/avi_k8s_controller_go $BUILD_PATH
+
+FROM scratch
+COPY --from=build $GOPATH/bin/avi_k8s_controller_go $GOPATH/bin/avi_k8s_controller_go
+ENTRYPOINT ["/go/bin/avi_k8s_controller_go"]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINARY_NAME=avi_k8s_controller_go
 REL_PATH=github.com/avinetworks/avi_k8s_controller
 
 .PHONY:all
-all: deps build
+all: deps build docker
 
 .PHONY: build
 build: 
@@ -20,4 +20,8 @@ clean:
 .PHONY: deps
 deps:
 		$(GOGET) -v $(REL_PATH)
+
+.PHONY: docker
+docker:
+	docker build -t $(BINARY_NAME):latest -f Dockerfile .
 

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: go-controller--deployment
+  labels:
+    app: avi-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: avi-controller
+  template:
+    metadata:
+      labels:
+        app: avi-controller
+    spec:
+      containers:
+      - name: avi-controller
+        image: avi_k8s_controller_go:latest
+        imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This fix introduces a Dockerfile to generate an image for the
Kubernetes Go Controller.

It also further introduces a deployment.yaml for kube based
deployments.

There's some adjustments made to the code to use the servicetokens
in kubernetes instead of config files to authenticate to the kube
api server.