### PR TITLE
Introduce secrets to store controller information

### DIFF
--- a/avi_k8s_controller/main.go
+++ b/avi_k8s_controller/main.go
@@ -93,8 +93,14 @@ func main() {
 	// TODO get API endpoint/username/password from configmap and track configmap
 	// for changes and update rest client
 
+	ctrlUsername := os.Getenv("CTRL_USERNAME")
+	ctrlPassword := os.Getenv("CTRL_PASSWORD")
+	ctrlIpAddress := os.Getenv("CTRL_IPADDRESS")
+	if ctrlUsername == "" || ctrlPassword == "" || ctrlIpAddress == "" {
+		AviLog.Error.Panic("AVI controller information missing. Update them in kubernetes secret or via environment variables.")
+	}
 	avi_rest_client_pool, err := NewAviRestClientPool(NumWorkers,
-		"10.70.119.34:9443", "admin", "avi123$%")
+		ctrlIpAddress, ctrlUsername, ctrlPassword)
 
 	k8s_ep := NewK8sEp(avi_obj_cache, avi_rest_client_pool, informers)
 	k8s_svc := NewK8sSvc(avi_obj_cache, avi_rest_client_pool, informers, k8s_ep)

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -18,3 +18,19 @@ spec:
       - name: avi-controller
         image: avi_k8s_controller_go:latest
         imagePullPolicy: IfNotPresent
+        env:
+        - name: CTRL_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: avi-secret
+              key: username
+        - name: CTRL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: avi-secret
+              key: password
+        - name: CTRL_IPADDRESS
+          valueFrom:
+            secretKeyRef:
+              name: avi-secret
+              key: controller_ip

--- a/kubernetes/secret.yaml
+++ b/kubernetes/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: avi-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: YWRtaW4=
+  controller_ip: MS4xLjEuMQ==


### PR DESCRIPTION
This patch introduces kubernetes secrets and makes the necessary
changes in the go controller to read from it.

NOTE: If you are using the go controller standalone outside of
kubernetes cluster, then set the environment variables with
controller details.