### PR TITLE
AV-55910: Create an MCP client for Galley

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ FROM golang:latest AS build
 ENV BUILD_PATH="github.com/avinetworks/avi_k8s_controller"
 RUN mkdir -p $GOPATH/src/$BUILD_PATH
 COPY avi_k8s_controller $GOPATH/src/$BUILD_PATH
-WORKDIR $BUILD_PATH
-RUN go get $BUILD_PATH
+WORKDIR $GOPATH/src/$BUILD_PATH
+RUN go get $BUILD_PATH; exit 0
+RUN rm -rf $GOPATH/src/istio.io/istio/vendor/github.com/gogo/googleapis/google/rpc
+RUN rm -rf $GOPATH/src/istio.io/istio/vendor/github.com/gogo/protobuf/types
+RUN rm -rf $GOPATH/src/istio.io/istio/vendor/istio.io/api/mcp/v1alpha1
+
 RUN GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -o $GOPATH/bin/avi_k8s_controller_go $BUILD_PATH
 
 FROM scratch

--- a/avi_k8s_controller/main.go
+++ b/avi_k8s_controller/main.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/avinetworks/avi_k8s_controller/pkg/mcp"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -57,7 +58,6 @@ func main() {
 	flag.Lookup("logtostderr").Value.Set("true")
 
 	AviLogInit()
-
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := SetupSignalHandler()
 	kubeCluster := false
@@ -68,7 +68,13 @@ func main() {
 		AviLog.Warning.Printf("We are not running inside kubernetes cluster. %s", err.Error())
 
 	} else {
-
+		// TODO (sudswas): Remove the hard coding later.
+		stop := make(chan struct{})
+		mcpServers := []string{"mcp://istio-galley.istio-system.svc:9901"}
+		mcpClient := mcp.MCPClient{MCPServerAddrs: mcpServers}
+		_ = mcpClient.InitMCPClient()
+		// TODO (sudswas): Need to handle the stop signal
+		mcpClient.Start(stop)
 		AviLog.Info.Println("We are running inside kubernetes cluster. Won't use kubeconfig files.")
 		kubeCluster = true
 

--- a/avi_k8s_controller/pkg/mcp/mcp_client.go
+++ b/avi_k8s_controller/pkg/mcp/mcp_client.go
@@ -1,0 +1,219 @@
+/*
+* [2013] - [2018] Avi Networks Incorporated
+* All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sync"
+
+	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc"
+	mcpapi "istio.io/api/mcp/v1alpha1"
+	istio_networking_v1alpha3 "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/mcp/client"
+	"istio.io/istio/pkg/mcp/configz"
+	"istio.io/istio/pkg/mcp/monitoring"
+	"istio.io/istio/pkg/mcp/sink"
+)
+
+const (
+
+	// DefaultMCPMaxMsgSize is the default maximum message size
+	DefaultMCPMaxMsgSize = 1024 * 1024 * 4
+)
+
+var (
+	// VirtualService describes v1alpha3 route rules
+	VirtualService = ProtoSchema{
+		Type:        "virtual-service",
+		Plural:      "virtual-services",
+		Group:       "networking",
+		Version:     "v1alpha3",
+		MessageName: "istio.networking.v1alpha3.VirtualService",
+		Validate:    ValidateVirtualService,
+		Collection:  "istio/networking/v1alpha3/virtualservices",
+	}
+	Gateway = ProtoSchema{
+		Type:        "gateway",
+		Plural:      "gateways",
+		Group:       "networking",
+		Version:     "v1alpha3",
+		MessageName: "istio.networking.v1alpha3.Gateway",
+		Validate:    ValidateGateway,
+		Collection:  "istio/networking/v1alpha3/gateways",
+	}
+	// ServiceEntry describes service entries
+	ServiceEntry = ProtoSchema{
+		Type:        "service-entry",
+		Plural:      "service-entries",
+		Group:       "networking",
+		Version:     "v1alpha3",
+		MessageName: "istio.networking.v1alpha3.ServiceEntry",
+		Validate:    ValidateServiceEntry,
+		Collection:  "istio/networking/v1alpha3/serviceentries",
+	}
+
+	// IstioConfigTypes lists all Istio config types with schemas and validation
+	IstioConfigTypes = ConfigDescriptor{
+		VirtualService,
+		Gateway,
+		ServiceEntry,
+	}
+)
+
+func ValidateVirtualService(name, namespace string, msg proto.Message) (errs error) {
+	fmt.Println("We will no-op for now")
+	// This is a bogus print log here to initialize the "istio.io/api/networking/v1alpha3"
+	// Can be removed when we use this package for more work.
+	fmt.Println(istio_networking_v1alpha3.TLSSettings_ISTIO_MUTUAL)
+	return
+}
+
+func ValidateGateway(name, namespace string, msg proto.Message) (errs error) {
+	fmt.Println("We will no-op for now")
+	// This is a bogus print log here to initialize the "istio.io/api/networking/v1alpha3"
+	// Can be removed when we use this package for more work.
+	fmt.Println(istio_networking_v1alpha3.TLSSettings_ISTIO_MUTUAL)
+	return
+}
+
+func ValidateServiceEntry(name, namespace string, msg proto.Message) (errs error) {
+	fmt.Println("We will no-op for now")
+	// This is a bogus print log here to initialize the "istio.io/api/networking/v1alpha3"
+	// Can be removed when we use this package for more work.
+	fmt.Println(istio_networking_v1alpha3.TLSSettings_ISTIO_MUTUAL)
+	return
+}
+
+type ConfigDescriptor []ProtoSchema
+
+type ProtoSchema struct {
+	ClusterScoped bool
+
+	Type string
+
+	Plural string
+
+	Group string
+
+	Version string
+
+	MessageName string
+
+	Validate func(name, namespace string, config proto.Message) error
+
+	Collection string
+}
+
+type MCPClient struct {
+	MCPServerAddrs []string
+	startFuncs     []startFunc
+}
+
+func (c *MCPClient) Start(stop <-chan struct{}) error {
+	// Now start all of the components.
+	for _, fn := range c.startFuncs {
+		if err := fn(stop); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *MCPClient) addStartFunc(fn startFunc) {
+	c.startFuncs = append(c.startFuncs, fn)
+}
+
+type startFunc func(stop <-chan struct{}) error
+
+func (c *MCPClient) InitMCPClient() error {
+	clientNodeID := ""
+	collections := make([]sink.CollectionOptions, len(IstioConfigTypes))
+	for i, model := range IstioConfigTypes {
+		collections[i] = sink.CollectionOptions{
+			Name: model.Collection,
+		}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	var clients []*client.Client
+	var conns []*grpc.ClientConn
+
+	reporter := monitoring.NewStatsContext("gocontroller/mcp/sink")
+
+	for _, addr := range c.MCPServerAddrs {
+		u, err := url.Parse(addr)
+		if err != nil {
+			cancel()
+			return err
+		}
+		fmt.Println("The MCP server address", u.Host)
+		securityOption := grpc.WithInsecure()
+		msgSizeOption := grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(DefaultMCPMaxMsgSize))
+		conn, err := grpc.DialContext(ctx, u.Host, securityOption, msgSizeOption)
+		if err != nil {
+			fmt.Errorf("Unable to dial MCP Server %q: %v", u.Host, err)
+			cancel()
+			return err
+		}
+		cl := mcpapi.NewAggregatedMeshConfigServiceClient(conn)
+		mcpController := NewController()
+		sinkOptions := &sink.Options{
+			CollectionOptions: collections,
+			Updater:           mcpController,
+			ID:                clientNodeID,
+			Reporter:          reporter,
+		}
+		mcpClient := client.New(cl, sinkOptions)
+		configz.Register(mcpClient)
+		fmt.Println("Successfully registered the client")
+		clients = append(clients, mcpClient)
+		conns = append(conns, conn)
+	}
+
+	c.addStartFunc(func(stop <-chan struct{}) error {
+		var wg sync.WaitGroup
+
+		for i := range clients {
+			client := clients[i]
+			wg.Add(1)
+			go func() {
+				client.Run(ctx)
+				wg.Done()
+			}()
+		}
+
+		go func() {
+			<-stop
+
+			// Stop the MCP clients and any pending connection.
+			cancel()
+
+			// Close all of the open grpc connections once the mcp
+			// client(s) have fully stopped.
+			wg.Wait()
+			for _, conn := range conns {
+				_ = conn.Close() // nolint: errcheck
+			}
+
+			reporter.Close()
+		}()
+
+		return nil
+	})
+	return nil
+}

--- a/avi_k8s_controller/pkg/mcp/mcp_controller.go
+++ b/avi_k8s_controller/pkg/mcp/mcp_controller.go
@@ -1,0 +1,68 @@
+/*
+* [2013] - [2018] Avi Networks Incorporated
+* All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package mcp
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"istio.io/istio/pkg/mcp/sink"
+)
+
+type Controller struct {
+	syncedMu                sync.Mutex
+	synced                  map[string]bool
+	descriptorsByCollection map[string]ProtoSchema
+}
+
+func NewController() *Controller {
+	synced := make(map[string]bool)
+	descriptorsByMessageName := make(map[string]ProtoSchema, len(IstioConfigTypes))
+	for _, descriptor := range IstioConfigTypes {
+		// don't register duplicate descriptors for the same collection
+		if _, ok := descriptorsByMessageName[descriptor.Collection]; !ok {
+			descriptorsByMessageName[descriptor.Collection] = descriptor
+			synced[descriptor.Collection] = false
+		}
+	}
+
+	return &Controller{
+		synced:                  synced,
+		descriptorsByCollection: descriptorsByMessageName,
+	}
+}
+
+// Apply receives changes from MCP server and creates the
+// corresponding config
+func (c *Controller) Apply(change *sink.Change) error {
+	c.syncedMu.Lock()
+	c.synced[change.Collection] = true
+	c.syncedMu.Unlock()
+	for _, obj := range change.Objects {
+		namespace, name := extractNameNamespace(obj.Metadata.Name)
+		fmt.Println("Got an update for name:  ", name)
+		fmt.Println("The namespace updated is: ", namespace)
+	}
+	return nil
+}
+
+func extractNameNamespace(metadataName string) (string, string) {
+	segments := strings.Split(metadataName, "/")
+	if len(segments) == 2 {
+		return segments[0], segments[1]
+	}
+	return "", segments[0]
+}


### PR DESCRIPTION
This PR creates a MCP client for the k8s controller that talks to
galley via a insecure grpc channel.

NOTE: This is just a basic code to test out the feasibility. The following improvements should be made going forward:

1. Improve logging to use the logger instead of fmt.
2. Add the mTLS support if the Istio cluster is using mTLS. 
3. Handle various error conditions w.r.t the Galley Server like server going down in between.


