### PR TITLE
AV-57354: De-couple infomers from WebApp updates - Part 1

### DIFF
--- a/avi_k8s_controller/main.go
+++ b/avi_k8s_controller/main.go
@@ -35,8 +35,6 @@ func main() {
 
 	flag.Lookup("logtostderr").Value.Set("true")
 
-	// set up signals so we handle the first shutdown signal gracefully
-	stopCh := SetupSignalHandler()
 	kubeCluster := false
 	// Check if we are running inside kubernetes. Hence try authenticating with service token
 	cfg, err := rest.InClusterConfig()
@@ -92,9 +90,9 @@ func main() {
 
 	c := NewAviController(NumWorkers, informers, kubeClient, k8s_ep, k8s_svc)
 
-	c.Start(stopCh)
+	c.Start()
 
-	c.Run(stopCh)
+	c.Run()
 }
 
 func init() {

--- a/avi_k8s_controller/types.go
+++ b/avi_k8s_controller/types.go
@@ -158,3 +158,8 @@ type AviHttpPolicySetMeta struct {
 	CloudConfigCksum string
 	HppMap           []AviHostPathPortPoolPG
 }
+
+type ChannelData struct {
+	key      string
+	workerId uint32
+}


### PR DESCRIPTION
Informers push their updates to the work queues. The work queue is maintained per worker thread.
The worker thread take out information from this work queue and make a AVI webapp call. In scale setups, the work queue would be busy making a webapp API call that may respond slowly. This would lead to an eventual degradation of the system performance. 

This patch frees the workers from processing requests and instead puts that work on independent go routines via a buffered channel. 

There is a go routine based on object type of kubernetes
that is - a go routine for ep and svc respectively for now.

The go routine is perpetually listening on the channel and processes them
when an update arrives. The buffer is assumed to be of 100 updates for now.
There's also a channel data type defined to carry out necessary communication
between the go routines.

TODOs:

1. There's a need to maintain a re-try cache to enqueue failed updates.
2. A webapp failure would kill the go routine for the respective object.
We need to re-design this by de-coupling the webapp logic from this distribution
layer.
3. More tests.