### PR TITLE
Don't kill the go controller if there's a web api error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ WORKDIR $GOPATH/src/$BUILD_PATH
 
 RUN GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -o $GOPATH/bin/servicemesh $BUILD_PATH
 
-FROM scratch
-COPY --from=build $GOPATH/bin/servicemesh $GOPATH/bin/servicemesh
-ENTRYPOINT ["/go/bin/servicemesh"]
+FROM alpine:latest
+COPY --from=build /go/bin/servicemesh .
+ENTRYPOINT ["./servicemesh"]

--- a/aviobjects/avi_obj_httpps.go
+++ b/aviobjects/avi_obj_httpps.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"os"
 
+	avimodels "github.com/avinetworks/sdk/go/models"
 	"github.com/avinetworks/servicemesh/pkg/utils"
 
-	avimodels "github.com/avinetworks/sdk/go/models"
 	"github.com/davecgh/go-spew/spew"
 )
 
@@ -30,7 +30,7 @@ func init() {
 	//Setting the package-wide version
 	CtrlVersion = os.Getenv("CTRL_VERSION")
 	if CtrlVersion == "" {
-		CtrlVersion = "19.1.1"
+		CtrlVersion = "18.2.2"
 	}
 }
 

--- a/aviobjects/avi_obj_pool.go
+++ b/aviobjects/avi_obj_pool.go
@@ -64,7 +64,7 @@ func AviPoolBuild(pool_meta *utils.K8sAviPoolMeta) *utils.RestOp {
 		Tenant: pool_meta.Tenant, Model: "Pool", Version: CtrlVersion}
 
 	utils.AviLog.Info.Print(spew.Sprintf("Pool Restop %v K8sAviPoolMeta %v\n",
-		rest_op, *pool_meta))
+		utils.Stringify(rest_op), *pool_meta))
 	return &rest_op
 }
 

--- a/aviobjects/avi_obj_vs.go
+++ b/aviobjects/avi_obj_vs.go
@@ -41,7 +41,6 @@ func AviVsBuild(vs_meta *utils.K8sAviVsMeta) []*utils.RestOp {
 	} else {
 		east_west = false
 	}
-
 	network_prof := "/api/networkprofile/?name=" + vs_meta.NetworkProfile
 	app_prof := "/api/applicationprofile/?name=" + vs_meta.ApplicationProfile
 	// TODO use PoolGroup and use policies if there are > 1 pool, etc.
@@ -123,7 +122,7 @@ func AviVsBuild(vs_meta *utils.K8sAviVsMeta) []*utils.RestOp {
 
 	rest_ops = append(rest_ops, &rest_op)
 
-	utils.AviLog.Info.Print(spew.Sprintf("VS Restop %v K8sAviVsMeta %v\n", rest_op,
+	utils.AviLog.Info.Print(spew.Sprintf("VS Restop %v K8sAviVsMeta %v\n", utils.Stringify(rest_op),
 		*vs_meta))
 	return rest_ops
 }

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ var (
 
 func main() {
 	flag.Parse()
-
 	flag.Lookup("logtostderr").Value.Set("true")
 
 	// set up signals so we handle the first shutdown signal gracefully

--- a/pkg/k8s/k8s_ep.go
+++ b/pkg/k8s/k8s_ep.go
@@ -220,6 +220,11 @@ func (p *K8sEp) K8sObjCrUpd(shard uint32, ep *corev1.Endpoints,
 		port_num, _ := strconv.Atoi(port)
 		protocol := s1[1]
 		pool_meta.Protocol = protocol
+		if len(ep.Subsets) == 0 {
+			// If this is an update on existing pool that had servers earlier but now the endpoint
+			// update has made the subsets to 0, we must set all the servers to 0 for all the pools for this service.
+			pool_meta.Servers = pool_meta.Servers[:0]
+		}
 		for _, ss := range ep.Subsets {
 			var epp_port int32
 			port_match := false

--- a/pkg/k8s/k8s_svc.go
+++ b/pkg/k8s/k8s_svc.go
@@ -129,6 +129,9 @@ func (s *K8sSvc) K8sObjCrUpd(shard uint32, svc *corev1.Service) ([]*utils.RestOp
 
 	if len(svc.Spec.Ports) == 1 {
 		for _, pool_rest_op := range pool_rest_ops {
+			// TODO (sudswas): What if a pool was created before and the service was created later?
+			// We will find it in the cache and hence rest_op won't have it.
+			// So we won't patch it.
 			if pool_rest_op.Model == "Pool" {
 				macro, ok := pool_rest_op.Obj.(utils.AviRestObjMacro)
 				if !ok {

--- a/pkg/utils/avi_rest_utils.go
+++ b/pkg/utils/avi_rest_utils.go
@@ -70,14 +70,16 @@ func (p *AviRestClientPool) AviRestOperate(c *clients.AviClient, rest_ops []*Res
 		if op.Err != nil {
 			AviLog.Warning.Printf(`RestOp method %v path %v tenant %v Obj %s 
                     returned err %v`, op.Method, op.Path, op.Tenant,
-				spew.Sprint(op.Obj), op.Err)
+				spew.Sprint(op.Obj), Stringify(op.Err))
 			for j := i + 1; j < len(rest_ops); j++ {
 				rest_ops[j].Err = errors.New("Aborted due to prev error")
 			}
-			return op.Err
+			// Wrap the error into a websync error.
+			err := &WebSyncError{err: op.Err, operation: string(op.Method)}
+			return err
 		} else {
 			AviLog.Info.Printf(`RestOp method %v path %v tenant %v response %v`,
-				op.Method, op.Path, op.Tenant, op.Response)
+				op.Method, op.Path, op.Tenant, Stringify(op.Response))
 		}
 	}
 	return nil

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"log"
 	"os"
@@ -33,4 +34,9 @@ func init() {
 	AviLog.Error = log.New(os.Stdout,
 		"ERROR: ",
 		log.Ldate|log.Ltime|log.Lshortfile)
+}
+
+func Stringify(serialize interface{}) string {
+	json_marshalled, _ := json.Marshal(serialize)
+	return string(json_marshalled)
 }

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -15,6 +15,8 @@
 package utils
 
 import (
+	"fmt"
+
 	avimodels "github.com/avinetworks/sdk/go/models"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	extinformers "k8s.io/client-go/informers/extensions/v1beta1"
@@ -163,4 +165,10 @@ type SkipSyncError struct {
 	Msg string
 }
 
+type WebSyncError struct {
+	err       error
+	operation string
+}
+
+func (e *WebSyncError) Error() string  { return fmt.Sprintf("Error during %s: %v", e.operation, e.err) }
 func (e *SkipSyncError) Error() string { return e.Msg }


### PR DESCRIPTION
This PR addresses a few concerns:
 - Don't kill the controller if web api throws an error. This required changing the scratch image to a alpine one.
 - Wrap errors. Not used completed yet.
 - Stringify structs for better logging.
 - Misc