### PR TITLE
Populate object and service to pool cache on restart.

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -163,11 +163,14 @@ func NewAviController(num_workers uint32, inf *utils.Informers, cs *kubernetes.C
 			c.workqueue[bkt].AddRateLimited(key)
 		},
 		UpdateFunc: func(old, cur interface{}) {
-			// TODO Check if anything has changed here ?
+			oldobj := old.(*corev1.Service)
 			svc := cur.(*corev1.Service)
-			key := "Service/" + utils.CrudHashKey("Service", svc) + "/" + ObjKey(svc)
-			bkt := Bkt(key, num_workers)
-			c.workqueue[bkt].AddRateLimited(key)
+			if oldobj.ResourceVersion != svc.ResourceVersion {
+				// Only add the key if the resource versions have changed.
+				key := "Service/" + utils.CrudHashKey("Service", svc) + "/" + ObjKey(svc)
+				bkt := Bkt(key, num_workers)
+				c.workqueue[bkt].AddRateLimited(key)
+			}
 		},
 	}
 

--- a/pkg/k8s/k8s_ep.go
+++ b/pkg/k8s/k8s_ep.go
@@ -33,16 +33,12 @@ import (
 type K8sEp struct {
 	avi_obj_cache        *utils.AviObjCache
 	avi_rest_client_pool *utils.AviRestClientPool
-	svc_to_pool_cache    *utils.AviMultiCache
-	svc_to_pg_cache      *utils.AviMultiCache
 	informers            *utils.Informers
 }
 
 func NewK8sEp(avi_obj_cache *utils.AviObjCache, avi_rest_client_pool *utils.AviRestClientPool,
 	inf *utils.Informers) *K8sEp {
 	p := K8sEp{}
-	p.svc_to_pool_cache = utils.NewAviMultiCache()
-	p.svc_to_pg_cache = utils.NewAviMultiCache()
 	p.avi_obj_cache = avi_obj_cache
 	p.avi_rest_client_pool = avi_rest_client_pool
 	p.informers = inf
@@ -139,7 +135,7 @@ func (p *K8sEp) K8sObjCrUpd(shard uint32, ep *corev1.Endpoints,
 		var pools_cache interface{}
 		var pools map[interface{}]bool
 		var ok bool
-		pools_cache, process_pool = p.svc_to_pool_cache.AviMultiCacheGetKey(k)
+		pools_cache, process_pool = p.avi_obj_cache.SvcToPoolCache.AviMultiCacheGetKey(k)
 		pools, ok = pools_cache.(map[interface{}]bool)
 		if process_pool && ok {
 			// ppool_name is of the form service/name-pool-http-tcp, ingress/name-pool-http-tcp
@@ -274,21 +270,4 @@ func (p *K8sEp) K8sObjCrUpd(shard uint32, ep *corev1.Endpoints,
 
 func (p *K8sEp) K8sObjDelete(shard uint32, key string) ([]*utils.RestOp, error) {
 	return nil, nil
-}
-
-func (p *K8sEp) K8sEpSvcToPoolCacheAdd(key utils.NamespaceName,
-	prefix string, rest_op *utils.RestOp) error {
-	err := aviobjects.AviSvcToPoolCacheAdd(p.svc_to_pool_cache, rest_op, prefix, key)
-
-	return err
-}
-
-func (p *K8sEp) K8sEpSvcToPoolCacheGet(key utils.NamespaceName) (map[interface{}]bool, bool) {
-	return p.svc_to_pool_cache.AviMultiCacheGetKey(key)
-}
-
-func (p *K8sEp) K8sEpSvcToPoolCacheDel(key utils.NamespaceName, prefix string) error {
-	err := aviobjects.AviSvcToPoolCacheDel(p.svc_to_pool_cache, prefix, key)
-
-	return err
 }

--- a/pkg/k8s/k8s_svc.go
+++ b/pkg/k8s/k8s_svc.go
@@ -201,8 +201,8 @@ func (s *K8sSvc) K8sObjCrUpd(shard uint32, svc *corev1.Service) ([]*utils.RestOp
 			if rest_op.Err == nil {
 				if rest_op.Model == "Pool" {
 					aviobjects.AviPoolCacheAdd(s.avi_obj_cache.PoolCache, rest_op)
-					s.k8s_ep.K8sEpSvcToPoolCacheAdd(vs_cache_key, "service",
-						rest_op)
+					aviobjects.AviSvcToPoolCacheAdd(s.avi_obj_cache.SvcToPoolCache, rest_op,
+						"service", vs_cache_key)
 				} else if rest_op.Model == "VirtualService" {
 					aviobjects.AviVsCacheAdd(s.avi_obj_cache.VsCache, rest_op)
 				}
@@ -261,7 +261,7 @@ func (s *K8sSvc) K8sObjDelete(shard uint32, key string) ([]*utils.RestOp, error)
 	 * [service/name-pool-http-tcp] = true
 	 * [ingress/name-pool-http-tcp] = true
 	 */
-	ppool_map, ok := s.k8s_ep.K8sEpSvcToPoolCacheGet(cache_key)
+	ppool_map, ok := s.avi_obj_cache.SvcToPoolCache.AviMultiCacheGetKey(cache_key)
 	if !ok {
 		utils.AviLog.Info.Printf("Key %v not found in SvcToPoolCache", cache_key)
 	} else {
@@ -283,7 +283,7 @@ func (s *K8sSvc) K8sObjDelete(shard uint32, key string) ([]*utils.RestOp, error)
 	}
 
 	utils.AviLog.Info.Printf("Delete key %v service in SvcToPoolCache", cache_key)
-	s.k8s_ep.K8sEpSvcToPoolCacheDel(cache_key, "service")
+	aviobjects.AviSvcToPoolCacheDel(s.avi_obj_cache.SvcToPoolCache, "service", cache_key)
 
 	utils.AviLog.Info.Printf("Delete VS %v in VsCache", cache_key)
 	aviobjects.AviVsCacheDel(s.avi_obj_cache.VsCache, cache_key)

--- a/pkg/utils/avi_obj_cache.go
+++ b/pkg/utils/avi_obj_cache.go
@@ -14,17 +14,239 @@
 
 package utils
 
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/avinetworks/sdk/go/clients"
+	"github.com/avinetworks/sdk/go/session"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
 type AviObjCache struct {
-	VsCache   *AviCache
-	PgCache   *AviCache
-	PoolCache *AviCache
+	client         *kubernetes.Clientset
+	VsCache        *AviCache
+	PgCache        *AviCache
+	PoolCache      *AviCache
+	SvcToPoolCache *AviMultiCache
+	SvcToPgCache   *AviMultiCache
+	informers      *Informers
 }
 
-func NewAviObjCache() *AviObjCache {
-	c := AviObjCache{}
+func NewAviObjCache(client *kubernetes.Clientset, informers *Informers) *AviObjCache {
+	c := AviObjCache{client: client, informers: informers}
 	c.VsCache = NewAviCache()
 	c.PgCache = NewAviCache()
 	c.PoolCache = NewAviCache()
-	// TODO Populate cache
+	c.SvcToPoolCache = NewAviMultiCache()
+	c.SvcToPgCache = NewAviMultiCache()
 	return &c
+}
+
+func (c *AviObjCache) AviObjCachePopulate(client *clients.AviClient,
+	version string, cloud string) {
+	SetTenant := session.SetTenant("*")
+	SetTenant(client.AviSession)
+	SetVersion := session.SetVersion(version)
+	SetVersion(client.AviSession)
+
+	var rest_response interface{}
+	var svc_mdata_obj ServiceMetadataObj
+	var svc_mdata interface{}
+	var svc_mdata_map map[string]interface{}
+	var err error
+	var pool_name string
+
+	avi_pools := make(map[string]bool)
+
+	// TODO Retrieve just fields we care about
+	uri := "/api/pool?include_name=true&cloud_ref.name=" + cloud
+	err = client.AviSession.Get(uri, &rest_response)
+
+	if err != nil {
+		AviLog.Warning.Printf(`Pool Get uri %v returned err %v`, uri, err)
+	} else {
+		resp, ok := rest_response.(map[string]interface{})
+		if !ok {
+			AviLog.Warning.Printf(`Pool Get uri %v returned %v type %T`, uri,
+				rest_response, rest_response)
+		} else {
+			AviLog.Info.Printf("Pool Get uri %v returned %v pools", uri,
+				resp["count"])
+			results, ok := resp["results"].([]interface{})
+			if !ok {
+				AviLog.Warning.Printf(`results not of type []interface{}
+							 Instead of type %T`, resp["results"])
+				return
+			}
+			for _, pool_intf := range results {
+				pool, ok := pool_intf.(map[string]interface{})
+				if !ok {
+					AviLog.Warning.Printf(`pool_intf not of type map[string]
+								 interface{}. Instead of type %T`, pool_intf)
+					continue
+				}
+				svc_mdata_intf, ok := pool["service_metadata"]
+				if ok {
+					if err := json.Unmarshal([]byte(svc_mdata_intf.(string)),
+						&svc_mdata); err == nil {
+						svc_mdata_map, ok = svc_mdata.(map[string]interface{})
+						if !ok {
+							AviLog.Warning.Printf(`resp %v svc_mdata %T has invalid
+								 service_metadata type`, pool, svc_mdata)
+						} else {
+							crkhey, ok := svc_mdata_map["crud_hash_key"]
+							if ok {
+								svc_mdata_obj.CrudHashKey = crkhey.(string)
+							} else {
+								AviLog.Warning.Printf(`service_metadata %v 
+									  malformed`, svc_mdata_map)
+							}
+						}
+					}
+				} else {
+					AviLog.Warning.Printf("service_metadata %v malformed", pool)
+				}
+
+				var tenant string
+				url, err := url.Parse(pool["tenant_ref"].(string))
+				if err != nil {
+					AviLog.Warning.Printf(`Error parsing tenant_ref %v in 
+										   pool %v`, pool["tenant_ref"], pool)
+					continue
+				} else if url.Fragment == "" {
+					AviLog.Warning.Printf(`Error extracting name tenant_ref %v 
+									 in pool %v`, pool["tenant_ref"], pool)
+					continue
+				} else {
+					tenant = url.Fragment
+				}
+
+				pool_cache_obj := AviPoolCache{Name: pool["name"].(string),
+					Tenant: tenant, Uuid: pool["uuid"].(string),
+					LbAlgorithm:      pool["lb_algorithm"].(string),
+					CloudConfigCksum: pool["cloud_config_cksum"].(string),
+					ServiceMetadata:  svc_mdata_obj}
+
+				avi_pools[pool_cache_obj.Name] = true
+
+				k := NamespaceName{Namespace: tenant, Name: pool["name"].(string)}
+				c.PoolCache.AviCacheAdd(k, &pool_cache_obj)
+
+				AviLog.Info.Printf("Added Pool cache k %v val %v",
+					k, pool_cache_obj)
+			}
+		}
+	}
+
+	// TODO Retrieve just fields we care about
+	uri = "/api/virtualservice?include_name=true&cloud_ref.name=" + cloud
+	err = client.AviSession.Get(uri, &rest_response)
+
+	if err != nil {
+		AviLog.Warning.Printf(`Vs Get uri %v returned err %v`, uri, err)
+	} else {
+		resp, ok := rest_response.(map[string]interface{})
+		if !ok {
+			AviLog.Warning.Printf(`Vs Get uri %v returned %v type %T`, uri,
+				rest_response, rest_response)
+		} else {
+			AviLog.Info.Printf("Vs Get uri %v returned %v vses", uri,
+				resp["count"])
+			results, ok := resp["results"].([]interface{})
+			if !ok {
+				AviLog.Warning.Printf(`results not of type []interface{}
+							 Instead of type %T`, resp["results"])
+				return
+			}
+			for _, vs_intf := range results {
+				vs, ok := vs_intf.(map[string]interface{})
+				if !ok {
+					AviLog.Warning.Printf(`vs_intf not of type map[string]
+								 interface{}. Instead of type %T`, vs_intf)
+					continue
+				}
+				svc_mdata_intf, ok := vs["service_metadata"]
+				if ok {
+					if err := json.Unmarshal([]byte(svc_mdata_intf.(string)),
+						&svc_mdata); err == nil {
+						svc_mdata_map, ok = svc_mdata.(map[string]interface{})
+						if !ok {
+							AviLog.Warning.Printf(`resp %v svc_mdata %T has invalid
+								 service_metadata type`, vs, svc_mdata)
+						} else {
+							crkhey, ok := svc_mdata_map["crud_hash_key"]
+							if ok {
+								svc_mdata_obj.CrudHashKey = crkhey.(string)
+							} else {
+								AviLog.Warning.Printf(`service_metadata %v 
+									  malformed`, svc_mdata_map)
+							}
+						}
+					}
+				}
+
+				var tenant string
+				url, err := url.Parse(vs["tenant_ref"].(string))
+				if err != nil {
+					AviLog.Warning.Printf(`Error parsing tenant_ref %v in 
+										   vs %v`, vs["tenant_ref"], vs)
+					continue
+				} else if url.Fragment == "" {
+					AviLog.Warning.Printf(`Error extracting name tenant_ref %v 
+									 in vs %v`, vs["tenant_ref"], vs)
+					continue
+				} else {
+					tenant = url.Fragment
+				}
+
+				vs_cache_obj := AviVsCache{Name: vs["name"].(string),
+					Tenant: tenant, Uuid: vs["uuid"].(string),
+					CloudConfigCksum: vs["cloud_config_cksum"].(string),
+					ServiceMetadata:  svc_mdata_obj}
+
+				k := NamespaceName{Namespace: tenant, Name: vs["name"].(string)}
+				c.VsCache.AviCacheAdd(k, &vs_cache_obj)
+
+				AviLog.Info.Printf("Added Vs cache k %v val %v",
+					k, vs_cache_obj)
+			}
+		}
+	}
+
+	// svcs, err := c.informers.ServiceInformer.Lister().List(labels.Everything())
+	svcs, err := c.client.CoreV1().Services("").List(v1.ListOptions{})
+	if err != nil {
+		AviLog.Warning.Printf("Service Lister returned %v", err)
+	} else {
+		for _, svc := range svcs.Items {
+			for _, pp := range svc.Spec.Ports {
+				var prot string
+				if pp.Protocol == "" {
+					prot = "tcp"
+				} else {
+					prot = strings.ToLower(string(pp.Protocol))
+				}
+				// pool_name is of the form name_prefix-pool-port-protocol
+				// For Service, name_prefix is the Service's name
+				pool_name = fmt.Sprintf("%s-pool-%v-%s", svc.Name,
+					pp.TargetPort.String(), prot)
+			}
+			_, pool_pres := avi_pools[pool_name]
+			if pool_pres {
+				key := NamespaceName{Namespace: svc.Namespace, Name: svc.Name}
+				pool_cache_entry := "service/" + pool_name
+				c.SvcToPoolCache.AviMultiCacheAdd(key, pool_cache_entry)
+				AviLog.Info.Printf(`key %v maps to pool %v in pool cache`,
+					key, pool_cache_entry)
+			} else {
+				AviLog.Warning.Printf(`Service namespace %v name %v pool %v
+					 has no corresponding pool`, svc.Namespace, svc.Name,
+					pool_name)
+			}
+		}
+	}
 }


### PR DESCRIPTION
On bootup of the go controller, we contact the configured avi
controller and fetch the necessary objects from AVI and populate
the cache entries in the go controller.

Another minor fix related to service updates.
Don't add a service to the queue if the resourceversions don't change.

Signed-off-by: rangar@avinetworks.com