### PR TITLE
Support for the REST layer, Destination Rules and subsets

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,5 +116,6 @@ func SyncFromIngestionLayer(key string) error {
 
 func SyncFromNodesLayer(key string) error {
 	// TBU
+	avirest.DeQueueNodes(key)
 	return nil
 }

--- a/pkg/istio/nodes/avi_model_nodes.go
+++ b/pkg/istio/nodes/avi_model_nodes.go
@@ -16,6 +16,7 @@ package nodes
 
 import (
 	"fmt"
+	"sort"
 
 	avimodels "github.com/avinetworks/sdk/go/models"
 	"github.com/avinetworks/servicemesh/pkg/utils"
@@ -78,6 +79,7 @@ type AviPoolNode struct {
 	PortName         string
 	Servers          []AviPoolMetaServer
 	Protocol         string
+	lbPolicy         string
 }
 
 func (v *AviPoolNode) GetCheckSum() uint32 {
@@ -130,7 +132,13 @@ func (v *AviHttpPolicySetNode) GetCheckSum() uint32 {
 
 func (v *AviHttpPolicySetNode) CalculateCheckSum() {
 	// A sum of fields for this VS.
-	checksum := utils.Hash(utils.Stringify(v.HppMap))
+	var checksum uint32
+	for _, hpp := range v.HppMap {
+		sort.Strings(hpp.Host)
+		sort.Strings(hpp.Path)
+		checksum = checksum + utils.Hash(utils.Stringify(hpp))
+	}
+	utils.AviLog.Info.Printf("The HTTP rules during checksum calculation is: %s with checksum: %v", utils.Stringify(v.HppMap), checksum)
 	v.CloudConfigCksum = checksum
 }
 

--- a/pkg/istio/nodes/avi_model_nodes.go
+++ b/pkg/istio/nodes/avi_model_nodes.go
@@ -79,7 +79,7 @@ type AviPoolNode struct {
 	PortName         string
 	Servers          []AviPoolMetaServer
 	Protocol         string
-	lbPolicy         string
+	LbAlgorithm      string
 }
 
 func (v *AviPoolNode) GetCheckSum() uint32 {
@@ -89,7 +89,7 @@ func (v *AviPoolNode) GetCheckSum() uint32 {
 
 func (v *AviPoolNode) CalculateCheckSum() {
 	// A sum of fields for this VS.
-	checksum := utils.Hash(v.Protocol) + utils.Hash(fmt.Sprint(v.Port)) + utils.Hash(v.PortName) + utils.Hash(utils.Stringify(v.Servers))
+	checksum := utils.Hash(v.Protocol) + utils.Hash(fmt.Sprint(v.Port)) + utils.Hash(v.PortName) + utils.Hash(utils.Stringify(v.Servers)) + utils.Hash(utils.Stringify(v.LbAlgorithm))
 	v.CloudConfigCksum = checksum
 }
 

--- a/pkg/istio/nodes/avi_model_translator.go
+++ b/pkg/istio/nodes/avi_model_translator.go
@@ -530,7 +530,7 @@ func (o *AviObjectGraph) extractServers(epObj *corev1.Endpoints, port_num int32,
 									if addr.NodeName != nil {
 										server.ServerNode = *addr.NodeName
 									}
-									if !Contains(pool_meta, server) {
+									if !utils.HasElem(pool_meta, server) {
 										pool_meta = append(pool_meta, server)
 									}
 								}
@@ -593,13 +593,4 @@ func (o *AviObjectGraph) BuildAviObjectGraph(namespace string, gatewayNs string,
 	o.GraphChecksum = o.GraphChecksum + VsNode.GetCheckSum()
 	utils.AviLog.Info.Printf("Checksum  for AVI VS object %v", VsNode.GetCheckSum())
 	utils.AviLog.Info.Printf("Computed Graph Checksum for VS is: %v", o.GraphChecksum)
-}
-
-func Contains(s []AviPoolMetaServer, e AviPoolMetaServer) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/istio/nodes/avi_model_translator.go
+++ b/pkg/istio/nodes/avi_model_translator.go
@@ -44,8 +44,14 @@ type AviObjectGraphIntf interface {
 }
 
 type AviObjectGraph struct {
-	modelNodes []AviModelNode
-	Name       string
+	modelNodes    []AviModelNode
+	Name          string
+	GraphChecksum uint32
+}
+
+func (v *AviObjectGraph) GetCheckSum() uint32 {
+	// Calculate checksum and return
+	return v.GraphChecksum
 }
 
 func NewAviObjectGraph() *AviObjectGraph {
@@ -137,9 +143,55 @@ func (o *AviObjectGraph) evaluateHTTPMatch(matchrule []*networking.HTTPMatchRequ
 	return checksum
 }
 
+func (o *AviObjectGraph) ProcessDRs(drList []string, poolNode *AviPoolNode, namespace string, subset string) map[string]string {
+	for _, drName := range drList {
+		found, istioObj := istio_objs.SharedDRLister().DestinationRule(namespace).Get(drName)
+		drSpec := istioObj.Spec.(*networking.DestinationRule)
+		if found {
+			if subset != "" {
+				// We need to apply the DR's specific subset rule for this pool
+				for _, drSubset := range drSpec.Subsets {
+					if subset == drSubset.Name {
+						lbSettings := drSubset.TrafficPolicy.LoadBalancer
+						o.selectPolicy(poolNode, lbSettings)
+						// Return the labels to search for.
+						return drSubset.Labels
+					}
+				}
+			} else {
+				lbSettings := drSpec.TrafficPolicy.LoadBalancer
+				o.selectPolicy(poolNode, lbSettings)
+				return nil
+			}
+			// TODO: Add support for consistent hash
+		} else {
+			utils.AviLog.Warning.Printf("DR object not found for DR name: %s", drName)
+		}
+	}
+	return nil
+}
+
+func (o *AviObjectGraph) selectPolicy(poolNode *AviPoolNode, lbSettings *networking.LoadBalancerSettings) {
+	if lbSettings == nil {
+		return
+	}
+	switch lbSettings.GetSimple() {
+	case networking.LoadBalancerSettings_LEAST_CONN:
+		poolNode.lbPolicy = utils.LeastConnection
+	case networking.LoadBalancerSettings_RANDOM:
+		poolNode.lbPolicy = utils.RandomConnection
+	case networking.LoadBalancerSettings_ROUND_ROBIN:
+		poolNode.lbPolicy = utils.RoundRobinConnection
+	case networking.LoadBalancerSettings_PASSTHROUGH:
+		poolNode.lbPolicy = utils.PassthroughConnection
+	}
+	return
+}
+
 func (o *AviObjectGraph) evaluateHTTPPools(ns string, randString string, destinations []*networking.HTTPRouteDestination, gatewayNs string) []*AviPoolNode {
 	var poolNodes []*AviPoolNode
 	for _, destination := range destinations {
+		var labels map[string]string
 		// For each destination, generate one pool. If weight is not present evalute it to 100.
 		serviceName := destination.Destination.Host
 		weight := destination.Weight
@@ -152,11 +204,17 @@ func (o *AviObjectGraph) evaluateHTTPPools(ns string, randString string, destina
 		// To be supported: obtain the servers for this service. Naming convention of the service is - svcname.ns.sub-domain
 		poolNode := &AviPoolNode{Name: poolName, Tenant: gatewayNs, Port: portNumber, Protocol: HTTP}
 		epObj, err := utils.GetInformers().EpInformer.Lister().Endpoints(ns).Get(serviceName)
+		// Get the destination rules for this service
+		found, destinationRules := istio_objs.SharedSvcLister().Service(ns).GetSvcToDR(serviceName)
+		if found {
+			// We need to process Destination Rules for this service
+			labels = o.ProcessDRs(destinationRules, poolNode, ns, destination.Destination.Subset)
+		}
 		if err != nil || epObj == nil {
 			// There's no endpoint object for the service.
 			poolNode.Servers = nil
 		} else {
-			poolNode.Servers = o.extractServers(epObj, portNumber, portName)
+			poolNode.Servers = o.extractServers(epObj, portNumber, portName, destination.Destination.Subset, ns, labels)
 		}
 		if portName != "" {
 			poolNode.PortName = portName
@@ -164,6 +222,8 @@ func (o *AviObjectGraph) evaluateHTTPPools(ns string, randString string, destina
 			poolNode.Port = portNumber
 		}
 		poolNode.CalculateCheckSum()
+		o.GraphChecksum = o.GraphChecksum + poolNode.GetCheckSum()
+		utils.AviLog.Info.Printf("Computed Graph Checksum after calculating pool nodes is :%v", o.GraphChecksum)
 		o.AddModelNode(poolNode)
 		poolNodes = append(poolNodes, poolNode)
 	}
@@ -223,7 +283,20 @@ func (o *AviObjectGraph) evaluateMatchCriteria(matches []*networking.HTTPMatchRe
 	return matchCriteria
 }
 
-func checkPGExists(pgNodes []*AviPoolGroupNode, evalchecksum uint32) (bool, *AviPoolGroupNode) {
+func checkPGExistsInCache(pgNodes []*utils.AviPGCache, evalchecksum uint32) (bool, *utils.AviPGCache) {
+	// Iterate through the PG nodes and check if the node exists with the checksum.
+	utils.AviLog.Info.Printf("Evaluated checksum for PG is %v", evalchecksum)
+	for _, pgNode := range pgNodes {
+		if pgNode.CloudConfigCksum == fmt.Sprint(evalchecksum) {
+			//Node exists - return true
+			utils.AviLog.Info.Printf("Match found for PGNode :%s", pgNode.Name)
+			return true, pgNode
+		}
+	}
+	return false, nil
+}
+
+func checkPGExistsInModel(pgNodes []*AviPoolGroupNode, evalchecksum uint32) (bool, *AviPoolGroupNode) {
 	// Iterate through the PG nodes and check if the node exists with the checksum.
 	for _, pgNode := range pgNodes {
 		if pgNode.RuleChecksum == evalchecksum {
@@ -270,11 +343,33 @@ func (o *AviObjectGraph) ConstructAviPGPoolNodes(vs *istio_objs.IstioObject, mod
 	vsObj, _ := vs.Spec.(*networking.VirtualService)
 	vsName := vs.ConfigMeta.Name
 	var poolGroupNodes []*AviPoolGroupNode
-	var prevPoolGroupNodes []*AviPoolGroupNode
+	var prevPoolGroupNodes []*utils.AviPGCache
+	var prevModelPoolGroupNodes []*AviPoolGroupNode
 	// Fetch the model if it exists for the AVI Vs.
+	cache := utils.SharedAviObjCache()
+	gwNs, gw := utils.ExtractGatewayNamespace(model_name)
+	vsKey := utils.NamespaceName{Namespace: gwNs, Name: gw}
+	vs_cache, ok := cache.VsCache.AviCacheGet(vsKey)
+	vs_cache_obj, ok := vs_cache.(*utils.AviVsCache)
+	utils.AviLog.Info.Printf("The VS Obj is in translate %v", utils.Stringify(vs_cache_obj))
+	if ok {
+		// There's a VS Cache - let's check the PGs
+		if vs_cache_obj.PGKeyCollection != nil {
+			for _, pg_key := range vs_cache_obj.PGKeyCollection {
+				utils.AviLog.Info.Printf("The pg key to search in cache is %v", pg_key)
+				pg_cache, ok := cache.PgCache.AviCacheGet(pg_key)
+				if ok {
+					pg_cache_obj, _ := pg_cache.(*utils.AviPGCache)
+					prevPoolGroupNodes = append(prevPoolGroupNodes, pg_cache_obj)
+					utils.AviLog.Info.Printf("Added node to prev PG nodes :%v", utils.Stringify(prevPoolGroupNodes))
+				}
+			}
+		}
+	}
+
 	found, aviModel := objects.SharedAviGraphLister().Get(model_name)
 	if found {
-		prevPoolGroupNodes = aviModel.(*AviObjectGraph).GetAviPoolGroups()
+		prevModelPoolGroupNodes = aviModel.(*AviObjectGraph).GetAviPoolGroups()
 	}
 	// HTTP route handling.
 
@@ -282,10 +377,17 @@ func (o *AviObjectGraph) ConstructAviPGPoolNodes(vs *istio_objs.IstioObject, mod
 		// Generate the PG to Rules map
 		rulechecksum := o.evaluateHTTPMatch(httpRoute.Match)
 		// Check if the PG already exists or needs to be created
-		exists, presentPGNode := checkPGExists(prevPoolGroupNodes, rulechecksum)
+		exists, presentPGNode := checkPGExistsInCache(prevPoolGroupNodes, rulechecksum)
 		var pgName string
 		if !exists {
-			pgName = o.generateRandomStringName(vsName)
+			// Check if it exists in the in memory model or not.
+			found, pgNodeFromModel := checkPGExistsInModel(prevModelPoolGroupNodes, rulechecksum)
+			if found {
+				utils.AviLog.Info.Printf("Found PG in the model nodes that has a match checksum, using name :%s", pgNodeFromModel.Name)
+				pgName = pgNodeFromModel.Name
+			} else {
+				pgName = o.generateRandomStringName(vsName)
+			}
 		} else {
 			utils.AviLog.Info.Printf("The PG %s exists in cache with the same checksum", presentPGNode.Name)
 			pgName = presentPGNode.Name
@@ -299,8 +401,10 @@ func (o *AviObjectGraph) ConstructAviPGPoolNodes(vs *istio_objs.IstioObject, mod
 			pgNode.Members = append(pgNode.Members, &avimodels.PoolGroupMember{PoolRef: &pool_ref})
 		}
 		pgNode.CalculateCheckSum()
+		o.GraphChecksum = o.GraphChecksum + pgNode.GetCheckSum()
 		o.AddModelNode(pgNode)
 		utils.AviLog.Info.Printf("Evaluated the PG :%v", utils.Stringify(pgNode))
+		utils.AviLog.Info.Printf("Computed Graph Checksum after PG node creation is %v", o.GraphChecksum)
 		poolGroupNodes = append(poolGroupNodes, pgNode)
 	}
 	return poolGroupNodes
@@ -318,9 +422,6 @@ func (o *AviObjectGraph) ConstructAviVsNode(gwObj *istio_objs.IstioObject) *AviV
 	avi_vs_meta.ApplicationProfile = "System-HTTP"
 	// For HTTP it's always System-TCP-Proxy.
 	avi_vs_meta.NetworkProfile = "System-TCP-Proxy"
-	avi_vs_meta.CalculateCheckSum()
-	utils.AviLog.Info.Printf("Checksum  for AVI VS object %v", avi_vs_meta.GetCheckSum())
-	utils.AviLog.Info.Printf("Evaluated PortProto %v", avi_vs_meta.PortProto)
 	//o.AddModelNode(avi_vs_meta)
 	return avi_vs_meta
 }
@@ -381,13 +482,15 @@ func (o *AviObjectGraph) ConstructAviHttpPolicyNodes(gatewayNs string, vsObj *is
 	}
 	policyNode := &AviHttpPolicySetNode{Name: vsObj.ConfigMeta.Name, HppMap: httpPolicySet, Tenant: gatewayNs}
 	policyNode.CalculateCheckSum()
+	o.GraphChecksum = o.GraphChecksum + policyNode.GetCheckSum()
 	utils.AviLog.Info.Printf("The value of HTTP Policy Set is :%s", utils.Stringify(policyNode))
 	utils.AviLog.Info.Printf("Computed Checksum for HTTP Policy Set is %v", policyNode.GetCheckSum())
+	utils.AviLog.Info.Printf("Computed Graph Checksum after evaluating nodes for HTTP Policy Set is %v", o.GraphChecksum)
 	o.AddModelNode(policyNode)
 	return policyNode
 }
 
-func (o *AviObjectGraph) extractServers(epObj *corev1.Endpoints, port_num int32, port_name string) []AviPoolMetaServer {
+func (o *AviObjectGraph) extractServers(epObj *corev1.Endpoints, port_num int32, port_name string, subsets string, ns string, subsetLabels map[string]string) []AviPoolMetaServer {
 	//TODO: The POD based subsets will be handled subsequently.
 	var pool_meta []AviPoolMetaServer
 	for _, ss := range epObj.Subsets {
@@ -404,18 +507,47 @@ func (o *AviObjectGraph) extractServers(epObj *corev1.Endpoints, port_num int32,
 			//pool_meta.Port = epp_port
 			for _, addr := range ss.Addresses {
 				var atype string
-				ip := addr.IP
-				if utils.IsV4(addr.IP) {
-					atype = "V4"
+				if subsets != "" {
+					// Only qualify the servers that are part of the subsets
+					podObj, err := utils.GetInformers().PodInformer.Lister().Pods(ns).Get(addr.TargetRef.Name)
+					if err == nil {
+						for labelkey, label := range podObj.Labels {
+							for subset_key, subset_label := range subsetLabels {
+								if labelkey == subset_key && label == subset_label {
+									ip := addr.IP
+									if utils.IsV4(addr.IP) {
+										atype = "V4"
+									} else {
+										atype = "V6"
+									}
+									a := avimodels.IPAddr{Type: &atype, Addr: &ip}
+									server := AviPoolMetaServer{Ip: a}
+									if addr.NodeName != nil {
+										server.ServerNode = *addr.NodeName
+									}
+									if !Contains(pool_meta, server) {
+										pool_meta = append(pool_meta, server)
+									}
+								}
+								utils.AviLog.Info.Printf("The POD object labels :%s", label)
+							}
+						}
+					}
+
 				} else {
-					atype = "V6"
+					ip := addr.IP
+					if utils.IsV4(addr.IP) {
+						atype = "V4"
+					} else {
+						atype = "V6"
+					}
+					a := avimodels.IPAddr{Type: &atype, Addr: &ip}
+					server := AviPoolMetaServer{Ip: a}
+					if addr.NodeName != nil {
+						server.ServerNode = *addr.NodeName
+					}
+					pool_meta = append(pool_meta, server)
 				}
-				a := avimodels.IPAddr{Type: &atype, Addr: &ip}
-				server := AviPoolMetaServer{Ip: a}
-				if addr.NodeName != nil {
-					server.ServerNode = *addr.NodeName
-				}
-				pool_meta = append(pool_meta, server)
 			}
 		}
 	}
@@ -451,5 +583,18 @@ func (o *AviObjectGraph) BuildAviObjectGraph(namespace string, gatewayNs string,
 			}
 		}
 	}
+	o.AddModelNode(VsNode)
+	VsNode.CalculateCheckSum()
+	o.GraphChecksum = o.GraphChecksum + VsNode.GetCheckSum()
+	utils.AviLog.Info.Printf("Checksum  for AVI VS object %v", VsNode.GetCheckSum())
+	utils.AviLog.Info.Printf("Computed Graph Checksum for VS is: %v", o.GraphChecksum)
+}
 
+func Contains(s []AviPoolMetaServer, e AviPoolMetaServer) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/istio/objects/destination_rule.go
+++ b/pkg/istio/objects/destination_rule.go
@@ -160,7 +160,7 @@ func (v *DRNSCache) UpdateSvcDRRefs(obj *IstioObject) {
 	var drList []string
 	service := v.GetServiceFromDRObj(obj)
 	_, drList = v.svcInstance.Service(obj.ConfigMeta.Namespace).GetSvcToDR(service)
-	if !Contains(drList, obj.ConfigMeta.Name) {
+	if !utils.HasElem(drList, obj.ConfigMeta.Name) {
 		drList = append(drList, obj.ConfigMeta.Name)
 	}
 	v.svcInstance.Service(obj.ConfigMeta.Namespace).UpdateSvcToDR(service, drList)

--- a/pkg/istio/objects/destination_rule.go
+++ b/pkg/istio/objects/destination_rule.go
@@ -1,0 +1,198 @@
+/*
+* [2013] - [2018] Avi Networks Incorporated
+* All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+//This module should give a wrapper over underlying objects to give easy API access for DR.
+
+package objects
+
+import (
+	"sync"
+
+	"github.com/avinetworks/servicemesh/pkg/utils"
+	networking "istio.io/api/networking/v1alpha3"
+)
+
+var drlisterinstance *DRLister
+var dronce sync.Once
+
+func SharedDRLister() *DRLister {
+	dronce.Do(func() {
+		DRStore := NewObjectStore()
+		drSvcStore := NewObjectStore()
+		drlisterinstance = &DRLister{}
+		drlisterinstance.drsvcstore = drSvcStore
+		drlisterinstance.drstore = DRStore
+	})
+	return drlisterinstance
+}
+
+type IstioDR interface {
+	DestinationRule(ns string) DRNameSpaceIntf
+	//List() *[]ObjectStore
+}
+
+type DRLister struct {
+	drstore    *ObjectStore
+	drsvcstore *ObjectStore
+}
+
+func (v *DRLister) DestinationRule(ns string) *DRNSCache {
+	nsDRObjects := v.drstore.GetNSStore(ns)
+	nsDRSvcObjects := v.drsvcstore.GetNSStore(ns)
+	svcInstance := SharedSvcLister()
+	return &DRNSCache{namespace: ns, drobjects: nsDRObjects, drsvcobjects: nsDRSvcObjects, svcInstance: svcInstance}
+}
+
+func (v *DRLister) GetAllDRs() map[string]map[string]string {
+	// This method should return a map that looks like this: {ns: [obj1, obj2]}
+	// This is particularly useful if we want to know what are the DR names
+	// present in a namespace without affecting the actual store objects.
+	allNamespaces := v.drstore.GetAllNamespaces()
+	allDRs := make(map[string]map[string]string)
+	if len(allNamespaces) != 0 {
+		// Iterate over each namespace and formulate the map
+		for _, ns := range allNamespaces {
+			allDRs[ns] = v.DestinationRule(ns).GetAllDRNameVers()
+		}
+	}
+	return allDRs
+
+}
+
+type DRNameSpaceIntf interface {
+	Get(name string) (bool, *IstioObject)
+	Update(obj IstioObject) bool
+	List() map[string]*IstioObject
+	Delete(name string) bool
+}
+
+type DRNSCache struct {
+	namespace    string
+	drobjects    *ObjectMapStore
+	drsvcobjects *ObjectMapStore
+	svcInstance  *SvcLister
+}
+
+func (v *DRNSCache) GetAllDRNameVers() map[string]string {
+	// Obtain the object for this DR
+	allObjects := v.drobjects.GetAllObjectNames()
+	objVersionsMap := make(map[string]string)
+	// Now let's parse the object names and their corresponding resourceversions in a Map
+	for _, obj := range allObjects {
+		objVersionsMap[obj.(*IstioObject).ConfigMeta.Name] = obj.(*IstioObject).ConfigMeta.ResourceVersion
+	}
+	return objVersionsMap
+}
+
+func (v *DRNSCache) Get(name string) (bool, *IstioObject) {
+	found, obj := v.drobjects.Get(name)
+	if !found {
+		// Do error wrapping here
+		return false, nil
+	} else {
+		return true, obj.(*IstioObject)
+	}
+}
+
+func (v *DRNSCache) GetSVCMapping(drname string) (bool, []string) {
+	found, obj := v.drsvcobjects.Get(drname)
+	if !found {
+		// Do error wrapping here
+		return false, nil
+	} else {
+		return true, obj.([]string)
+	}
+}
+
+func (v *DRNSCache) Update(obj *IstioObject) {
+	v.drobjects.AddOrUpdate(obj.Name, obj)
+}
+
+func (v *DRNSCache) UpdateDRToSVCMapping(drName string, svc string) {
+	v.drsvcobjects.AddOrUpdate(drName, svc)
+}
+
+func (v *DRNSCache) Delete(name string) bool {
+	return v.drobjects.Delete(name)
+}
+
+func (v *DRNSCache) List() map[string]*IstioObject {
+	// TODO (sudswas): Let's check if we can abstract out the store objects
+	// completely. There's still a possibility that if we pass the references
+	// we maybe allowing upper layers to modify the object that would directly
+	// impact the store objects.
+	convertedMap := make(map[string]*IstioObject)
+	// Change the empty interface to IstioObject. Avoid Duck Typing.
+	for key, value := range v.drobjects.ObjectMap {
+		convertedMap[key] = value.(*IstioObject)
+	}
+	return convertedMap
+}
+
+func (v *DRNSCache) GetServiceFromDRObj(dr *IstioObject) string {
+	drObj, ok := dr.Spec.(*networking.DestinationRule)
+	if !ok {
+		// This is not the right object to cast to VirtualService return error.
+		utils.AviLog.Warning.Printf("Wrong object passed. Expecting a DestinationRule object %v", drObj)
+		return ""
+	}
+	if len(drObj.Host) == 0 {
+		utils.AviLog.Warning.Println("There are no Services found for this Destination Rule")
+		return ""
+	}
+
+	return drObj.Host
+
+}
+
+func (v *DRNSCache) UpdateSvcDRRefs(obj *IstioObject) {
+	var drList []string
+	service := v.GetServiceFromDRObj(obj)
+	_, drList = v.svcInstance.Service(obj.ConfigMeta.Namespace).GetSvcToDR(service)
+	if !Contains(drList, obj.ConfigMeta.Name) {
+		drList = append(drList, obj.ConfigMeta.Name)
+	}
+	v.svcInstance.Service(obj.ConfigMeta.Namespace).UpdateSvcToDR(service, drList)
+	utils.AviLog.Info.Printf("The Service associated with this DR: %s is %s ", obj.ConfigMeta.Name, service)
+	v.UpdateDRToSVCMapping(obj.ConfigMeta.Name, service)
+}
+
+func (v *DRNSCache) GetSvcForDR(drName string) (bool, string) {
+	// Need checks if it's found or not?
+	found, svc := v.drsvcobjects.Get(drName)
+	if !found {
+		return false, ""
+	}
+	return true, svc.(string)
+}
+
+func (v *DRNSCache) DeleteDRToSvc(drName string) {
+	// Need checks if it's found or not?
+	v.drsvcobjects.Delete(drName)
+}
+
+func (v *DRNSCache) DeleteSVCToDRRefs(drName string, namespace string) {
+	// Need checks if it's found or not?
+	found, svc := v.drsvcobjects.Get(drName)
+	if found {
+		var drList []string
+		var ok bool
+		ok, drList = v.svcInstance.Service(namespace).GetSvcToDR(svc.(string))
+		if ok {
+			drList = Remove(drList, drName)
+			v.svcInstance.Service(namespace).UpdateSvcToDR(svc.(string), drList)
+		}
+	}
+	v.DeleteDRToSvc(drName)
+}

--- a/pkg/istio/objects/virtual_service.go
+++ b/pkg/istio/objects/virtual_service.go
@@ -165,7 +165,7 @@ func (v *VirtualServiceNSCache) DeleteVSToGw(vsName string) {
 
 func (v *VirtualServiceNSCache) DeleteGwToVsRefs(gwName string, vsName string) {
 	_, vsList := v.gwInstance.Gateway(v.namespace).GetVSMapping(gwName)
-	if Contains(vsList, vsName) {
+	if utils.HasElem(vsList, vsName) {
 		vsList = Remove(vsList, vsName)
 	}
 	v.gwInstance.Gateway(v.namespace).UpdateGWVSMapping(gwName, vsList)
@@ -186,7 +186,7 @@ func (v *VirtualServiceNSCache) UpdateGatewayVsRefs(obj *IstioObject) {
 		_, vsList := v.gwInstance.Gateway(ns).GetVSMapping(gateway)
 		// Update the VS with it's own namespace.
 		vsName := obj.ConfigMeta.Namespace + "/" + obj.ConfigMeta.Name
-		if Contains(vsList, vsName) {
+		if utils.HasElem(vsList, vsName) {
 			// The vsName is already added, continue
 			continue
 		}
@@ -204,13 +204,13 @@ func (v *VirtualServiceNSCache) UpdateSvcVSRefs(obj *IstioObject) {
 	utils.AviLog.Info.Printf("The Services associated with VS: %s is %s ", obj.ConfigMeta.Name, services)
 	for _, service := range services {
 		_, vsList := v.svcInstance.Service(obj.ConfigMeta.Namespace).GetSvcToVS(service)
-		if !Contains(vsList, obj.ConfigMeta.Name) {
+		if !utils.HasElem(vsList, obj.ConfigMeta.Name) {
 			vsList = append(vsList, obj.ConfigMeta.Name)
 			v.svcInstance.Service(obj.ConfigMeta.Namespace).UpdateSvcToVSMapping(service, vsList)
 		}
 	}
 	// Now update the VS to SVC relationship
-	if !Contains(services, obj.ConfigMeta.Name) {
+	if !utils.HasElem(services, obj.ConfigMeta.Name) {
 		v.vsToSvcInstance.AddOrUpdate(obj.ConfigMeta.Name, services)
 	}
 }
@@ -219,7 +219,7 @@ func (v *VirtualServiceNSCache) DeleteSvcToVs(vsName string) {
 	services := v.GetVSToSVC(vsName)
 	for _, service := range services {
 		_, vsList := v.svcInstance.Service(v.namespace).GetSvcToVS(service)
-		if Contains(vsList, vsName) {
+		if utils.HasElem(vsList, vsName) {
 			vsList = Remove(vsList, vsName)
 		}
 		v.svcInstance.Service(v.namespace).UpdateSvcToVSMapping(service, vsList)
@@ -288,15 +288,6 @@ func (v *VirtualServiceNSCache) GetServiceForVS(vs *IstioObject) []string {
 
 	return svcs
 
-}
-
-func Contains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
 }
 
 func Remove(s []string, r string) []string {

--- a/pkg/istio/objects/virtual_service.go
+++ b/pkg/istio/objects/virtual_service.go
@@ -204,11 +204,15 @@ func (v *VirtualServiceNSCache) UpdateSvcVSRefs(obj *IstioObject) {
 	utils.AviLog.Info.Printf("The Services associated with VS: %s is %s ", obj.ConfigMeta.Name, services)
 	for _, service := range services {
 		_, vsList := v.svcInstance.Service(obj.ConfigMeta.Namespace).GetSvcToVS(service)
-		vsList = append(vsList, obj.ConfigMeta.Name)
-		v.svcInstance.Service(obj.ConfigMeta.Namespace).UpdateSvcToVSMapping(service, vsList)
+		if !Contains(vsList, obj.ConfigMeta.Name) {
+			vsList = append(vsList, obj.ConfigMeta.Name)
+			v.svcInstance.Service(obj.ConfigMeta.Namespace).UpdateSvcToVSMapping(service, vsList)
+		}
 	}
 	// Now update the VS to SVC relationship
-	v.vsToSvcInstance.AddOrUpdate(obj.ConfigMeta.Name, services)
+	if !Contains(services, obj.ConfigMeta.Name) {
+		v.vsToSvcInstance.AddOrUpdate(obj.ConfigMeta.Name, services)
+	}
 }
 
 func (v *VirtualServiceNSCache) DeleteSvcToVs(vsName string) {

--- a/pkg/istio/rest/avi_obj_httpps.go
+++ b/pkg/istio/rest/avi_obj_httpps.go
@@ -148,7 +148,7 @@ func AviHTTPPolicyCacheAdd(cache *utils.AviObjCache, rest_op *utils.RestOp, vsKe
 				if vs_cache_obj.HTTPKeyCollection == nil {
 					vs_cache_obj.HTTPKeyCollection = []utils.NamespaceName{k}
 				} else {
-					if !Contains(vs_cache_obj.HTTPKeyCollection, k) {
+					if !utils.HasElem(vs_cache_obj.HTTPKeyCollection, k) {
 						vs_cache_obj.HTTPKeyCollection = append(vs_cache_obj.HTTPKeyCollection, k)
 					}
 				}

--- a/pkg/istio/rest/avi_obj_httpps.go
+++ b/pkg/istio/rest/avi_obj_httpps.go
@@ -1,0 +1,184 @@
+/*
+ * [2013] - [2018] Avi Networks Incorporated
+ * All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest
+
+import (
+	"errors"
+	"fmt"
+
+	avimodels "github.com/avinetworks/sdk/go/models"
+	"github.com/avinetworks/servicemesh/pkg/istio/nodes"
+	"github.com/avinetworks/servicemesh/pkg/utils"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func AviHttpPSBuild(hps_meta *nodes.AviHttpPolicySetNode, cache_obj *utils.AviHTTPCache) *utils.RestOp {
+	name := hps_meta.Name
+	cksum := hps_meta.CloudConfigCksum
+	cksumString := fmt.Sprint(cksum)
+	tenant := fmt.Sprintf("/api/tenant/?name=%s", hps_meta.Tenant)
+	cr := utils.OSHIFT_K8S_CLOUD_CONNECTOR
+
+	http_req_pol := avimodels.HTTPRequestPolicy{}
+	hps := avimodels.HTTPPolicySet{Name: &name, CloudConfigCksum: &cksumString,
+		CreatedBy: &cr, TenantRef: &tenant, HTTPRequestPolicy: &http_req_pol}
+
+	var idx int32
+	idx = 0
+	for _, hppmap := range hps_meta.HppMap {
+		enable := true
+		name := fmt.Sprintf("%s-%d", hps_meta.Name, idx)
+		match_target := avimodels.MatchTarget{}
+		if len(hppmap.Host) > 0 {
+			match_crit := "HDR_EQUALS"
+			host_hdr_match := avimodels.HostHdrMatch{MatchCriteria: &match_crit,
+				Value: hppmap.Host}
+			match_target.HostHdr = &host_hdr_match
+		}
+		if len(hppmap.Path) > 0 {
+			match_crit := hppmap.MatchCriteria
+			path_match := avimodels.PathMatch{MatchCriteria: &match_crit,
+				MatchStr: hppmap.Path}
+			match_target.Path = &path_match
+		}
+		if hppmap.Port != 0 {
+			match_crit := "IS_IN"
+			vsport_match := avimodels.PortMatch{MatchCriteria: &match_crit,
+				Ports: []int64{int64(hppmap.Port)}}
+			match_target.VsPort = &vsport_match
+		}
+		sw_action := avimodels.HttpswitchingAction{}
+		if hppmap.Pool != "" {
+			action := "HTTP_SWITCHING_SELECT_POOL"
+			sw_action.Action = &action
+			pool_ref := fmt.Sprintf("/api/pool/?name=%s", hppmap.Pool)
+			sw_action.PoolRef = &pool_ref
+		} else if hppmap.PoolGroup != "" {
+			action := "HTTP_SWITCHING_SELECT_POOLGROUP"
+			sw_action.Action = &action
+			pg_ref := fmt.Sprintf("/api/poolgroup/?name=%s", hppmap.PoolGroup)
+			sw_action.PoolGroupRef = &pg_ref
+		}
+		var j int32
+		j = idx
+		rule := avimodels.HTTPRequestRule{Enable: &enable, Index: &j,
+			Name: &name, Match: &match_target, SwitchingAction: &sw_action}
+		http_req_pol.Rules = append(http_req_pol.Rules, &rule)
+		idx = idx + 1
+	}
+
+	macro := utils.AviRestObjMacro{ModelName: "HTTPPolicySet", Data: hps}
+	var path string
+	var rest_op utils.RestOp
+	if cache_obj != nil {
+		path = "/api/httppolicyset/" + cache_obj.Uuid
+		rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: hps,
+			Tenant: hps_meta.Tenant, Model: "HTTPPolicySet", Version: utils.CtrlVersion}
+
+	} else {
+		path = "/api/macro"
+		rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: macro,
+			Tenant: hps_meta.Tenant, Model: "HTTPPolicySet", Version: utils.CtrlVersion}
+	}
+
+	utils.AviLog.Info.Print(spew.Sprintf("HTTPPolicySet Restop %v AviHttpPolicySetMeta %v\n",
+		rest_op, *hps_meta))
+	return &rest_op
+}
+
+func AviHttpPolicyDel(uuid string, tenant string) *utils.RestOp {
+	path := "/api/httppolicyset/" + uuid
+	rest_op := utils.RestOp{Path: path, Method: "DELETE",
+		Tenant: tenant, Model: "HTTPPolicySet", Version: utils.CtrlVersion}
+	utils.AviLog.Info.Print(spew.Sprintf("HTTP Policy Set DELETE Restop %v \n",
+		utils.Stringify(rest_op)))
+	return &rest_op
+}
+
+func AviHTTPPolicyCacheAdd(cache *utils.AviObjCache, rest_op *utils.RestOp, vsKey utils.NamespaceName) error {
+	if (rest_op.Err != nil) || (rest_op.Response == nil) {
+		utils.AviLog.Warning.Printf("rest_op has err or no reponse for HTTP Policy Set Objects")
+		return errors.New("Errored rest_op")
+	}
+
+	resp_elems, ok := RestRespArrToObjByType(rest_op, "httppolicyset")
+	if ok != nil || resp_elems == nil {
+		utils.AviLog.Warning.Printf("Unable to find HTTP Policy Set obj in resp %v", rest_op.Response)
+		return errors.New("HTTP Policy Set object not found")
+	}
+
+	for _, resp := range resp_elems {
+		name, ok := resp["name"].(string)
+		if !ok {
+			utils.AviLog.Warning.Printf("Name not present in response %v", resp)
+			continue
+		}
+
+		uuid, ok := resp["uuid"].(string)
+		if !ok {
+			utils.AviLog.Warning.Printf("Uuid not present in response %v", resp)
+			continue
+		}
+
+		cksum := resp["cloud_config_cksum"].(string)
+
+		http_cache_obj := utils.AviHTTPCache{Name: name, Tenant: rest_op.Tenant,
+			Uuid:             uuid,
+			CloudConfigCksum: cksum}
+
+		k := utils.NamespaceName{Namespace: rest_op.Tenant, Name: name}
+		cache.HTTPCache.AviCacheAdd(k, &http_cache_obj)
+		vs_cache, ok := cache.VsCache.AviCacheGet(vsKey)
+		if ok {
+			vs_cache_obj, found := vs_cache.(*utils.AviVsCache)
+			if found {
+				if vs_cache_obj.HTTPKeyCollection == nil {
+					vs_cache_obj.HTTPKeyCollection = []utils.NamespaceName{k}
+				} else {
+					if !Contains(vs_cache_obj.HTTPKeyCollection, k) {
+						vs_cache_obj.HTTPKeyCollection = append(vs_cache_obj.HTTPKeyCollection, k)
+					}
+				}
+				utils.AviLog.Info.Printf("Modified the VS cache for https object. The cache now is :%v", utils.Stringify(vs_cache_obj))
+			}
+
+		} else {
+			vs_cache_obj := utils.AviVsCache{Name: vsKey.Name, Tenant: vsKey.Namespace,
+				HTTPKeyCollection: []utils.NamespaceName{k}}
+			cache.VsCache.AviCacheAdd(vsKey, &vs_cache_obj)
+			utils.AviLog.Info.Print(spew.Sprintf("Added VS cache key during http policy update %v val %v\n", vsKey,
+				vs_cache_obj))
+		}
+		utils.AviLog.Info.Print(spew.Sprintf("Added Http Policy Set cache k %v val %v\n", k,
+			http_cache_obj))
+	}
+
+	return nil
+}
+
+func AviHTTPCacheDel(cache *utils.AviObjCache, rest_op *utils.RestOp, vsKey utils.NamespaceName) error {
+	key := utils.NamespaceName{Namespace: rest_op.Tenant, Name: rest_op.ObjName}
+	cache.HTTPCache.AviCacheDelete(key)
+	vs_cache, ok := cache.VsCache.AviCacheGet(vsKey)
+	if ok {
+		vs_cache_obj, found := vs_cache.(*utils.AviVsCache)
+		if found {
+			vs_cache_obj.HTTPKeyCollection = Remove(vs_cache_obj.HTTPKeyCollection, key)
+		}
+	}
+
+	return nil
+}

--- a/pkg/istio/rest/avi_obj_pool.go
+++ b/pkg/istio/rest/avi_obj_pool.go
@@ -1,0 +1,307 @@
+/*
+ * [2013] - [2018] Avi Networks Incorporated
+ * All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	avimodels "github.com/avinetworks/sdk/go/models"
+	"github.com/avinetworks/servicemesh/pkg/istio/nodes"
+	"github.com/avinetworks/servicemesh/pkg/utils"
+	"github.com/davecgh/go-spew/spew"
+)
+
+func AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj *utils.AviPoolCache) *utils.RestOp {
+	name := pool_meta.Name
+	cksum := pool_meta.CloudConfigCksum
+	cksumString := fmt.Sprint(cksum)
+	tenant := fmt.Sprintf("/api/tenant/?name=%s", pool_meta.Tenant)
+	svc_mdata_json, _ := json.Marshal(&pool_meta.ServiceMetadata)
+	svc_mdata := string(svc_mdata_json)
+	cr := utils.OSHIFT_K8S_CLOUD_CONNECTOR
+
+	pool := avimodels.Pool{Name: &name, CloudConfigCksum: &cksumString,
+		CreatedBy: &cr, TenantRef: &tenant, ServiceMetadata: &svc_mdata}
+
+	// TODO other fields like cloud_ref and lb algo
+
+	for _, server := range pool_meta.Servers {
+		sip := server.Ip
+		port := pool_meta.Port
+		s := avimodels.Server{IP: &sip, Port: &port}
+		if server.ServerNode != "" {
+			sn := server.ServerNode
+			s.ServerNode = &sn
+		}
+		pool.Servers = append(pool.Servers, &s)
+	}
+
+	var hm string
+	if pool_meta.Protocol == "udp" {
+		hm = fmt.Sprintf("/api/healthmonitor/?name=%s", utils.AVI_DEFAULT_UDP_HM)
+	} else {
+		hm = fmt.Sprintf("/api/healthmonitor/?name=%s", utils.AVI_DEFAULT_TCP_HM)
+	}
+	pool.HealthMonitorRefs = append(pool.HealthMonitorRefs, hm)
+
+	macro := utils.AviRestObjMacro{ModelName: "Pool", Data: pool}
+
+	// TODO Version should be latest from configmap
+	var path string
+	var rest_op utils.RestOp
+	if cache_obj != nil {
+		path = "/api/pool/" + cache_obj.Uuid
+		rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: pool,
+			Tenant: pool_meta.Tenant, Model: "Pool", Version: utils.CtrlVersion}
+
+	} else {
+		path = "/api/macro"
+		rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: macro,
+			Tenant: pool_meta.Tenant, Model: "Pool", Version: utils.CtrlVersion}
+	}
+
+	utils.AviLog.Info.Print(spew.Sprintf("Pool Restop %v K8sAviPoolMeta %v\n",
+		utils.Stringify(rest_op), *pool_meta))
+	return &rest_op
+}
+
+func AviPoolDel(uuid string, tenant string) *utils.RestOp {
+	path := "/api/pool/" + uuid
+	rest_op := utils.RestOp{Path: path, Method: "DELETE",
+		Tenant: tenant, Model: "Pool", Version: utils.CtrlVersion}
+	utils.AviLog.Info.Print(spew.Sprintf("Pool DELETE Restop %v \n",
+		utils.Stringify(rest_op)))
+	return &rest_op
+}
+
+func AviPoolCacheAdd(cache *utils.AviObjCache, rest_op *utils.RestOp, vsKey utils.NamespaceName) error {
+	if (rest_op.Err != nil) || (rest_op.Response == nil) {
+		utils.AviLog.Warning.Printf("rest_op has err or no reponse")
+		return errors.New("Errored rest_op")
+	}
+
+	resp_elems, ok := RestRespArrToObjByType(rest_op, "pool")
+	if ok != nil || resp_elems == nil {
+		utils.AviLog.Warning.Printf("Unable to find pool obj in resp %v", rest_op.Response)
+		return errors.New("pool not found")
+	}
+
+	for _, resp := range resp_elems {
+		name, ok := resp["name"].(string)
+		if !ok {
+			utils.AviLog.Warning.Printf("Name not present in response %v", resp)
+			continue
+		}
+
+		uuid, ok := resp["uuid"].(string)
+		if !ok {
+			utils.AviLog.Warning.Printf("Uuid not present in response %v", resp)
+			continue
+		}
+
+		lb := resp["lb_algorithm"].(string)
+		cksum := resp["cloud_config_cksum"].(string)
+
+		var svc_mdata interface{}
+		var svc_mdata_map map[string]interface{}
+		var svc_mdata_obj utils.ServiceMetadataObj
+
+		if err := json.Unmarshal([]byte(resp["service_metadata"].(string)),
+			&svc_mdata); err == nil {
+			svc_mdata_map, ok = svc_mdata.(map[string]interface{})
+			if !ok {
+				utils.AviLog.Warning.Printf(`resp %v svc_mdata %T has invalid 
+                            service_metadata type`, resp, svc_mdata)
+				svc_mdata_obj = utils.ServiceMetadataObj{}
+			} else {
+				SvcMdataMapToObj(&svc_mdata_map, &svc_mdata_obj)
+			}
+		} else {
+			utils.AviLog.Warning.Printf(`resp %v has invalid service_metadata value 
+                                  err %v`, resp, err)
+			svc_mdata_obj = utils.ServiceMetadataObj{}
+		}
+
+		pool_cache_obj := utils.AviPoolCache{Name: name, Tenant: rest_op.Tenant,
+			Uuid: uuid, LbAlgorithm: lb,
+			CloudConfigCksum: cksum, ServiceMetadata: svc_mdata_obj}
+
+		k := utils.NamespaceName{Namespace: rest_op.Tenant, Name: name}
+		cache.PoolCache.AviCacheAdd(k, &pool_cache_obj)
+		// Update the VS object
+		vs_cache, ok := cache.VsCache.AviCacheGet(vsKey)
+		if ok {
+			vs_cache_obj, found := vs_cache.(*utils.AviVsCache)
+			if found {
+				if vs_cache_obj.PoolKeyCollection == nil {
+					vs_cache_obj.PoolKeyCollection = []utils.NamespaceName{k}
+				} else {
+					if !Contains(vs_cache_obj.PoolKeyCollection, k) {
+						vs_cache_obj.PoolKeyCollection = append(vs_cache_obj.PoolKeyCollection, k)
+					}
+				}
+				utils.AviLog.Info.Printf("Modified the VS cache object for Pool Collection. The cache now is :%v", utils.Stringify(vs_cache_obj))
+			}
+		} else {
+			vs_cache_obj := utils.AviVsCache{Name: vsKey.Name, Tenant: vsKey.Namespace,
+				PoolKeyCollection: []utils.NamespaceName{k}}
+			cache.VsCache.AviCacheAdd(vsKey, &vs_cache_obj)
+			utils.AviLog.Info.Print(spew.Sprintf("Added VS cache key during pool update %v val %v\n", vsKey,
+				vs_cache_obj))
+		}
+		utils.AviLog.Info.Print(spew.Sprintf("Added Pool cache k %v val %v\n", k,
+			pool_cache_obj))
+	}
+
+	return nil
+}
+
+func SvcMdataMapToObj(svc_mdata_map *map[string]interface{}, svc_mdata *utils.ServiceMetadataObj) {
+	for k, val := range *svc_mdata_map {
+		switch k {
+		case "crud_hash_key":
+			crkhey, ok := val.(string)
+			if ok {
+				svc_mdata.CrudHashKey = crkhey
+			} else {
+				utils.AviLog.Warning.Printf("Incorrect type %T in svc_mdata_map %v", val, *svc_mdata_map)
+			}
+		}
+	}
+}
+
+// TODO (sudswas): Let's move this to utils when we move types.go to utils.
+func RestRespArrToObjByType(rest_op *utils.RestOp, obj_type string) ([]map[string]interface{}, error) {
+	var resp_elems []map[string]interface{}
+
+	if rest_op.Method == utils.RestPost {
+		resp_arr, ok := rest_op.Response.([]interface{})
+
+		if !ok {
+			utils.AviLog.Warning.Printf("Response has unknown type %T", rest_op.Response)
+			return nil, errors.New("Malformed response")
+		}
+
+		for _, resp_elem := range resp_arr {
+			resp, ok := resp_elem.(map[string]interface{})
+			if !ok {
+				utils.AviLog.Warning.Printf("Response has unknown type %T", resp_elem)
+				continue
+			}
+
+			avi_url, ok := resp["url"].(string)
+			if !ok {
+				utils.AviLog.Warning.Printf("url not present in response %v", resp)
+				continue
+			}
+
+			avi_obj_type, err := utils.AviUrlToObjType(avi_url)
+			if err == nil && avi_obj_type == obj_type {
+				resp_elems = append(resp_elems, resp)
+			}
+		}
+	} else {
+		// The PUT calls are specific for the resource
+		resp_elems = append(resp_elems, rest_op.Response.(map[string]interface{}))
+	}
+
+	return resp_elems, nil
+}
+
+func AviPoolCacheDel(cache *utils.AviObjCache, rest_op *utils.RestOp, vsKey utils.NamespaceName) error {
+	key := utils.NamespaceName{Namespace: rest_op.Tenant, Name: rest_op.ObjName}
+	cache.PoolCache.AviCacheDelete(key)
+	// Delete the pool from the vs cache as well.
+	vs_cache, ok := cache.VsCache.AviCacheGet(vsKey)
+	if ok {
+		vs_cache_obj, found := vs_cache.(*utils.AviVsCache)
+		if found {
+			vs_cache_obj.PoolKeyCollection = Remove(vs_cache_obj.PoolKeyCollection, key)
+		}
+	}
+
+	return nil
+}
+
+func AviSvcToPoolCacheAdd(svc_to_pool_cache *utils.AviMultiCache, rest_op *utils.RestOp,
+	prefix string, key utils.NamespaceName) error {
+	if (rest_op.Err != nil) || (rest_op.Response == nil) {
+		utils.AviLog.Warning.Printf("rest_op has err or no reponse")
+		return errors.New("Errored rest_op")
+	}
+
+	resp_elems, ok := RestRespArrToObjByType(rest_op, "pool")
+	if ok != nil || resp_elems == nil {
+		utils.AviLog.Warning.Printf("Unable to find pool obj in resp %v", rest_op.Response)
+		return errors.New("pool not found")
+	}
+
+	/*
+	 * SvcToPoolCache is of the form:
+	 * (ns, name) -> (service/name-pool-http-tcp, route/name-route-pool-http-tcp)
+	 * Set of all Pools that are affected by change in same endpoints
+	 */
+
+	for _, resp := range resp_elems {
+		name, ok := resp["name"].(string)
+		if !ok {
+			utils.AviLog.Warning.Printf("Name not present in response %v", resp)
+			continue
+		}
+
+		pool_cache_entry := prefix + "/" + name
+
+		svc_to_pool_cache.AviMultiCacheAdd(key, pool_cache_entry)
+		utils.AviLog.Info.Printf("Added key %v pool %v to SvcToPoolCache", key,
+			pool_cache_entry)
+	}
+
+	return nil
+}
+
+func AviSvcToPoolCacheDel(svc_to_pool_cache *utils.AviMultiCache,
+	prefix string, key utils.NamespaceName) error {
+	/*
+	 * mkey_map is of the form:
+	 * [service/name-pool-http-tcp] = true
+	 * [ingress/name-pool-http-tcp] = true
+	 */
+	mkey_map, ok := svc_to_pool_cache.AviMultiCacheGetKey(key)
+
+	if !ok {
+		utils.AviLog.Info.Printf("Key %v not found in svc_to_pool_cache", key)
+		return nil
+	}
+
+	for ppool_name_intf := range mkey_map {
+		ppool_name, ok := ppool_name_intf.(string)
+		if !ok {
+			utils.AviLog.Warning.Printf("ppool_name_intf %T is not type string",
+				ppool_name_intf)
+			continue
+		}
+		elems := strings.Split(ppool_name, "/")
+		if prefix == elems[0] {
+			utils.AviLog.Info.Printf("Key %v val %s deleted in svc_to_pool_cache",
+				key, ppool_name)
+			svc_to_pool_cache.AviMultiCacheDeleteVal(key, ppool_name)
+		}
+	}
+
+	return nil
+}

--- a/pkg/istio/rest/avi_obj_pool.go
+++ b/pkg/istio/rest/avi_obj_pool.go
@@ -160,7 +160,7 @@ func AviPoolCacheAdd(cache *utils.AviObjCache, rest_op *utils.RestOp, vsKey util
 				if vs_cache_obj.PoolKeyCollection == nil {
 					vs_cache_obj.PoolKeyCollection = []utils.NamespaceName{k}
 				} else {
-					if !Contains(vs_cache_obj.PoolKeyCollection, k) {
+					if !utils.HasElem(vs_cache_obj.PoolKeyCollection, k) {
 						utils.AviLog.Info.Printf("Before adding pool collection %v and key :%v", vs_cache_obj.PoolKeyCollection, k)
 						vs_cache_obj.PoolKeyCollection = append(vs_cache_obj.PoolKeyCollection, k)
 					}

--- a/pkg/istio/rest/avi_obj_vs.go
+++ b/pkg/istio/rest/avi_obj_vs.go
@@ -1,0 +1,221 @@
+/*
+ * [2013] - [2018] Avi Networks Incorporated
+ * All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	avimodels "github.com/avinetworks/sdk/go/models"
+	"github.com/avinetworks/servicemesh/pkg/istio/nodes"
+	"github.com/avinetworks/servicemesh/pkg/utils"
+	"github.com/davecgh/go-spew/spew"
+)
+
+func AviVsBuild(vs_meta *nodes.AviVsNode, httppolicynode []*nodes.AviHttpPolicySetNode, rest_method utils.RestMethod, cache_obj *utils.AviVsCache) []*utils.RestOp {
+	var vip avimodels.Vip
+	if rest_method == utils.RestPost {
+		auto_alloc := true
+		vip = avimodels.Vip{AutoAllocateIP: &auto_alloc}
+	} else {
+		auto_alloc_put := true
+		vipId := "0"
+		auto_allocate_floating_ip := false
+		vip = avimodels.Vip{AutoAllocateIP: &auto_alloc_put, VipID: &vipId, AutoAllocateFloatingIP: &auto_allocate_floating_ip}
+	}
+	// E/W placement subnet is don't care, just needs to be a valid subnet
+	mask := int32(24)
+	addr := "172.18.0.0"
+	atype := "V4"
+	sip := avimodels.IPAddr{Type: &atype, Addr: &addr}
+	ew_subnet := avimodels.IPAddrPrefix{IPAddr: &sip, Mask: &mask}
+	var east_west bool
+	if vs_meta.EastWest == true {
+		vip.Subnet = &ew_subnet
+		east_west = true
+	} else {
+		east_west = false
+	}
+	network_prof := "/api/networkprofile/?name=" + vs_meta.NetworkProfile
+	app_prof := "/api/applicationprofile/?name=" + vs_meta.ApplicationProfile
+	// TODO use PoolGroup and use policies if there are > 1 pool, etc.
+	name := vs_meta.Name
+	cksum := vs_meta.CloudConfigCksum
+	checksumstr := fmt.Sprint(cksum)
+	cr := utils.OSHIFT_K8S_CLOUD_CONNECTOR
+	tenant_ref := "https://10.52.2.37:9443/api/tenant/tenant-902769f1-f427-436c-a35c-fd0502b05269#istio-system"
+	vs := avimodels.VirtualService{Name: &name,
+		NetworkProfileRef:     &network_prof,
+		ApplicationProfileRef: &app_prof,
+		CloudConfigCksum:      &checksumstr,
+		CreatedBy:             &cr,
+		EastWestPlacement:     &east_west,
+		TenantRef:             &tenant_ref}
+
+	if vs_meta.DefaultPoolGroup != "" {
+		pool_ref := "/api/poolgroup/?name=" + vs_meta.DefaultPoolGroup
+		vs.PoolGroupRef = &pool_ref
+	}
+	vs.Vip = append(vs.Vip, &vip)
+	// } else {
+	// 	utils.AviLog.Info.Printf("Using the VS VIF information from cache")
+	// 	vip_id := "0"
+	// 	vip.VipID = &vip_id
+	// 	aviAuto := true
+	// 	vip.AviAllocatedVip = &aviAuto
+	// 	auto_alloc_ip_type := "V4_ONLY"
+	// 	vip.AutoAllocateIPType = &auto_alloc_ip_type
+	// 	nsAddr := "10.52.59.100"
+	// 	ns := avimodels.IPAddr{Type: &atype, Addr: &nsAddr}
+	// 	vip.IPAddress = &ns
+	// 	//vs.Vip = cache_obj.Vip.([]*avimodels.Vip)
+	// 	vs.Vip = append(vs.Vip, &vip)
+	// }
+
+	tenant := fmt.Sprintf("/api/tenant/?name=%s", vs_meta.Tenant)
+	vs.TenantRef = &tenant
+	svc_meta_json, _ := json.Marshal(&vs_meta.ServiceMetadata)
+	svc_meta := string(svc_meta_json)
+	vs.ServiceMetadata = &svc_meta
+
+	// TODO other fields like cloud_ref, mix of TCP & UDP protocols, etc.
+
+	for _, pp := range vs_meta.PortProto {
+		port := pp.Port
+		svc := avimodels.Service{Port: &port}
+		if pp.Protocol == "tcp" && vs_meta.NetworkProfile == "System-UDP-Fast-Path" {
+			onw_profile := "/api/networkprofile/?name=System-TCP-Proxy"
+			svc.OverrideNetworkProfileRef = &onw_profile
+		} else if pp.Protocol == "udp" && vs_meta.NetworkProfile == "System-TCP-Proxy" {
+			onw_profile := "/api/networkprofile/?name=System-UDP-Fast-Path"
+			svc.OverrideNetworkProfileRef = &onw_profile
+		}
+		vs.Services = append(vs.Services, &svc)
+	}
+
+	var rest_ops []*utils.RestOp
+
+	var i int32
+	i = 0
+	var httpPolicyCollection []*avimodels.HTTPPolicies
+	for _, http := range httppolicynode {
+		// Update them on the VS object
+		var j int32
+		j = i + 14
+		i = i + 1
+		httpPolicy := fmt.Sprintf("/api/httppolicyset/?name=%s", http.Name)
+		httpPolicies := &avimodels.HTTPPolicies{HTTPPolicySetRef: &httpPolicy, Index: &j}
+		httpPolicyCollection = append(httpPolicyCollection, httpPolicies)
+	}
+	vs.HTTPPolicies = httpPolicyCollection
+	var rest_op utils.RestOp
+	var path string
+	if rest_method == utils.RestPut {
+		path = "/api/virtualservice/" + cache_obj.Uuid
+		rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: vs,
+			Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion}
+	} else {
+		macro := utils.AviRestObjMacro{ModelName: "VirtualService", Data: vs}
+		path = "/api/macro"
+		rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: macro,
+			Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion}
+	}
+
+	rest_ops = append(rest_ops, &rest_op)
+
+	utils.AviLog.Info.Print(spew.Sprintf("VS Restop %v K8sAviVsMeta %v\n", utils.Stringify(rest_op),
+		*vs_meta))
+	return rest_ops
+}
+
+func AviVsCacheAdd(cache *utils.AviObjCache, rest_op *utils.RestOp) error {
+	if (rest_op.Err != nil) || (rest_op.Response == nil) {
+		utils.AviLog.Warning.Printf("rest_op has err or no reponse")
+		return errors.New("Errored rest_op")
+	}
+
+	resp_elems, ok := RestRespArrToObjByType(rest_op, "virtualservice")
+	if ok != nil || resp_elems == nil {
+		utils.AviLog.Warning.Printf("Unable to find pool obj in resp %v", rest_op.Response)
+		return errors.New("pool not found")
+	}
+
+	for _, resp := range resp_elems {
+		name, ok := resp["name"].(string)
+		if !ok {
+			utils.AviLog.Warning.Printf("Name not present in response %v", resp)
+			return errors.New("Name not present in response")
+		}
+
+		uuid, ok := resp["uuid"].(string)
+		if !ok {
+			utils.AviLog.Warning.Printf("Uuid not present in response %v", resp)
+			return errors.New("Uuid not present in response")
+		}
+
+		cksum := resp["cloud_config_cksum"].(string)
+		utils.AviLog.Info.Printf("VS INFORMATION %s", utils.Stringify(resp))
+		var svc_mdata interface{}
+		var svc_mdata_map map[string]interface{}
+		var svc_mdata_obj utils.ServiceMetadataObj
+
+		if err := json.Unmarshal([]byte(resp["service_metadata"].(string)),
+			&svc_mdata); err == nil {
+			svc_mdata_map, ok = svc_mdata.(map[string]interface{})
+			if !ok {
+				utils.AviLog.Warning.Printf(`resp %v svc_mdata %T has invalid 
+								service_metadata type`, resp, svc_mdata)
+				svc_mdata_obj = utils.ServiceMetadataObj{}
+			} else {
+				SvcMdataMapToObj(&svc_mdata_map, &svc_mdata_obj)
+			}
+		} else {
+			utils.AviLog.Warning.Printf("resp %v has invalid service_metadata value",
+				resp)
+			svc_mdata_obj = utils.ServiceMetadataObj{}
+		}
+
+		k := utils.NamespaceName{Namespace: rest_op.Tenant, Name: name}
+		vs_cache, ok := cache.VsCache.AviCacheGet(k)
+		if ok {
+			vs_cache_obj, found := vs_cache.(*utils.AviVsCache)
+			if found {
+				vs_cache_obj.Uuid = uuid
+				vs_cache_obj.CloudConfigCksum = cksum
+				utils.AviLog.Info.Print(spew.Sprintf("Updated VS cache key %v val %v\n", k,
+					utils.Stringify(vs_cache_obj)))
+			}
+		} else {
+			vs_cache_obj := utils.AviVsCache{Name: name, Tenant: rest_op.Tenant,
+				Uuid: uuid, CloudConfigCksum: cksum,
+				ServiceMetadata: svc_mdata_obj}
+			cache.VsCache.AviCacheAdd(k, &vs_cache_obj)
+			utils.AviLog.Info.Print(spew.Sprintf("Added VS cache key %v val %v\n", k,
+				vs_cache_obj))
+		}
+
+	}
+
+	return nil
+}
+
+func AviVsCacheDel(vs_cache *utils.AviCache, rest_op *utils.RestOp) error {
+
+	key := utils.NamespaceName{Namespace: rest_op.Tenant, Name: rest_op.ObjName}
+	vs_cache.AviCacheDelete(key)
+
+	return nil
+}

--- a/pkg/istio/rest/avi_obj_vs.go
+++ b/pkg/istio/rest/avi_obj_vs.go
@@ -56,14 +56,12 @@ func AviVsBuild(vs_meta *nodes.AviVsNode, httppolicynode []*nodes.AviHttpPolicyS
 	cksum := vs_meta.CloudConfigCksum
 	checksumstr := fmt.Sprint(cksum)
 	cr := utils.OSHIFT_K8S_CLOUD_CONNECTOR
-	tenant_ref := "https://10.52.2.37:9443/api/tenant/tenant-902769f1-f427-436c-a35c-fd0502b05269#istio-system"
 	vs := avimodels.VirtualService{Name: &name,
 		NetworkProfileRef:     &network_prof,
 		ApplicationProfileRef: &app_prof,
 		CloudConfigCksum:      &checksumstr,
 		CreatedBy:             &cr,
-		EastWestPlacement:     &east_west,
-		TenantRef:             &tenant_ref}
+		EastWestPlacement:     &east_west}
 
 	if vs_meta.DefaultPoolGroup != "" {
 		pool_ref := "/api/poolgroup/?name=" + vs_meta.DefaultPoolGroup

--- a/pkg/istio/rest/avi_pool_group.go
+++ b/pkg/istio/rest/avi_pool_group.go
@@ -126,7 +126,7 @@ func AviPGCacheAdd(cache *utils.AviObjCache, rest_op *utils.RestOp, vsKey utils.
 				if vs_cache_obj.PGKeyCollection == nil {
 					vs_cache_obj.PGKeyCollection = []utils.NamespaceName{k}
 				} else {
-					if !Contains(vs_cache_obj.PGKeyCollection, k) {
+					if !utils.HasElem(vs_cache_obj.PGKeyCollection, k) {
 						vs_cache_obj.PGKeyCollection = append(vs_cache_obj.PGKeyCollection, k)
 					}
 				}

--- a/pkg/istio/rest/avi_pool_group.go
+++ b/pkg/istio/rest/avi_pool_group.go
@@ -1,0 +1,162 @@
+/*
+ * [2013] - [2018] Avi Networks Incorporated
+ * All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	avimodels "github.com/avinetworks/sdk/go/models"
+	"github.com/avinetworks/servicemesh/pkg/istio/nodes"
+	"github.com/avinetworks/servicemesh/pkg/utils"
+	"github.com/davecgh/go-spew/spew"
+)
+
+func AviPoolGroupBuild(pg_meta *nodes.AviPoolGroupNode, cache_obj *utils.AviPGCache) *utils.RestOp {
+	name := pg_meta.Name
+	cksum := pg_meta.CloudConfigCksum
+	cksumString := fmt.Sprint(cksum)
+	tenant := fmt.Sprintf("/api/tenant/?name=%s", pg_meta.Tenant)
+	svc_mdata_json, _ := json.Marshal(&pg_meta.ServiceMetadata)
+	svc_mdata := string(svc_mdata_json)
+	members := pg_meta.Members
+	cr := utils.OSHIFT_K8S_CLOUD_CONNECTOR
+	pg := avimodels.PoolGroup{Name: &name, CloudConfigCksum: &cksumString,
+		CreatedBy: &cr, TenantRef: &tenant, ServiceMetadata: &svc_mdata, Members: members}
+	// TODO other fields like cloud_ref and lb algo
+
+	macro := utils.AviRestObjMacro{ModelName: "PoolGroup", Data: pg}
+
+	var path string
+	var rest_op utils.RestOp
+	if cache_obj != nil {
+		path = "/api/poolgroup/" + cache_obj.Uuid
+		rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: pg,
+			Tenant: pg_meta.Tenant, Model: "PoolGroup", Version: utils.CtrlVersion}
+	} else {
+		path = "/api/macro"
+		rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: macro,
+			Tenant: pg_meta.Tenant, Model: "PoolGroup", Version: utils.CtrlVersion}
+	}
+
+	return &rest_op
+}
+
+func AviPGDel(uuid string, tenant string) *utils.RestOp {
+	path := "/api/poolgroup/" + uuid
+	rest_op := utils.RestOp{Path: path, Method: "DELETE",
+		Tenant: tenant, Model: "PoolGroup", Version: utils.CtrlVersion}
+	utils.AviLog.Info.Print(spew.Sprintf("PG DELETE Restop %v \n",
+		utils.Stringify(rest_op)))
+	return &rest_op
+}
+
+func AviPGCacheAdd(cache *utils.AviObjCache, rest_op *utils.RestOp, vsKey utils.NamespaceName) error {
+	if (rest_op.Err != nil) || (rest_op.Response == nil) {
+		utils.AviLog.Warning.Printf("rest_op has err or no reponse for PG")
+		return errors.New("Errored rest_op")
+	}
+
+	resp_elems, ok := RestRespArrToObjByType(rest_op, "poolgroup")
+	if ok != nil || resp_elems == nil {
+		utils.AviLog.Warning.Printf("Unable to find pool group obj in resp %v", rest_op.Response)
+		return errors.New("poolgroup not found")
+	}
+
+	for _, resp := range resp_elems {
+		name, ok := resp["name"].(string)
+		if !ok {
+			utils.AviLog.Warning.Printf("Name not present in response %v", resp)
+			continue
+		}
+
+		uuid, ok := resp["uuid"].(string)
+		if !ok {
+			utils.AviLog.Warning.Printf("Uuid not present in response %v", resp)
+			continue
+		}
+
+		cksum := resp["cloud_config_cksum"].(string)
+
+		var svc_mdata interface{}
+		var svc_mdata_map map[string]interface{}
+		var svc_mdata_obj utils.ServiceMetadataObj
+
+		if err := json.Unmarshal([]byte(resp["service_metadata"].(string)),
+			&svc_mdata); err == nil {
+			svc_mdata_map, ok = svc_mdata.(map[string]interface{})
+			if !ok {
+				utils.AviLog.Warning.Printf(`resp %v svc_mdata %T has invalid
+                            service_metadata type`, resp, svc_mdata)
+				svc_mdata_obj = utils.ServiceMetadataObj{}
+			} else {
+				SvcMdataMapToObj(&svc_mdata_map, &svc_mdata_obj)
+			}
+		} else {
+			utils.AviLog.Warning.Printf(`resp %v has invalid service_metadata value
+                                  err %v`, resp, err)
+			svc_mdata_obj = utils.ServiceMetadataObj{}
+		}
+
+		pg_cache_obj := utils.AviPGCache{Name: name, Tenant: rest_op.Tenant,
+			Uuid:             uuid,
+			CloudConfigCksum: cksum, ServiceMetadata: svc_mdata_obj}
+
+		k := utils.NamespaceName{Namespace: rest_op.Tenant, Name: name}
+		cache.PgCache.AviCacheAdd(k, &pg_cache_obj)
+		// Update the VS object
+		vs_cache, ok := cache.VsCache.AviCacheGet(vsKey)
+		if ok {
+			vs_cache_obj, found := vs_cache.(*utils.AviVsCache)
+			if found {
+				if vs_cache_obj.PGKeyCollection == nil {
+					vs_cache_obj.PGKeyCollection = []utils.NamespaceName{k}
+				} else {
+					if !Contains(vs_cache_obj.PGKeyCollection, k) {
+						vs_cache_obj.PGKeyCollection = append(vs_cache_obj.PGKeyCollection, k)
+					}
+				}
+				utils.AviLog.Info.Printf("Modified the VS cache object for PG collection. The cache now is :%v", utils.Stringify(vs_cache_obj))
+			}
+
+		} else {
+			vs_cache_obj := utils.AviVsCache{Name: vsKey.Name, Tenant: vsKey.Namespace,
+				PGKeyCollection: []utils.NamespaceName{k}}
+			cache.VsCache.AviCacheAdd(vsKey, &vs_cache_obj)
+			utils.AviLog.Info.Print(spew.Sprintf("Added VS cache key during poolgroup update %v val %v\n", vsKey,
+				vs_cache_obj))
+		}
+		utils.AviLog.Info.Print(spew.Sprintf("Added PG cache k %v val %v\n", k,
+			pg_cache_obj))
+	}
+
+	return nil
+}
+
+func AviPGCacheDel(cache *utils.AviObjCache, rest_op *utils.RestOp, vsKey utils.NamespaceName) error {
+	key := utils.NamespaceName{Namespace: rest_op.Tenant, Name: rest_op.ObjName}
+	cache.PgCache.AviCacheDelete(key)
+	vs_cache, ok := cache.VsCache.AviCacheGet(vsKey)
+	if ok {
+		vs_cache_obj, found := vs_cache.(*utils.AviVsCache)
+		if found {
+			vs_cache_obj.PGKeyCollection = Remove(vs_cache_obj.PGKeyCollection, key)
+		}
+	}
+
+	return nil
+
+}

--- a/pkg/istio/rest/avi_pool_group.go
+++ b/pkg/istio/rest/avi_pool_group.go
@@ -122,6 +122,7 @@ func AviPGCacheAdd(cache *utils.AviObjCache, rest_op *utils.RestOp, vsKey utils.
 		if ok {
 			vs_cache_obj, found := vs_cache.(*utils.AviVsCache)
 			if found {
+				utils.AviLog.Info.Printf("The VS cache before modification by PG creation is :%v", utils.Stringify(vs_cache_obj))
 				if vs_cache_obj.PGKeyCollection == nil {
 					vs_cache_obj.PGKeyCollection = []utils.NamespaceName{k}
 				} else {

--- a/pkg/istio/rest/dequeue_nodes.go
+++ b/pkg/istio/rest/dequeue_nodes.go
@@ -1,0 +1,338 @@
+/*
+* [2013] - [2019] Avi Networks Incorporated
+* All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package rest
+
+import (
+	"fmt"
+
+	"github.com/avinetworks/servicemesh/pkg/istio/nodes"
+	"github.com/avinetworks/servicemesh/pkg/istio/objects"
+	"github.com/avinetworks/servicemesh/pkg/utils"
+)
+
+func DeQueueNodes(key string) {
+	// Got the key from the Graph Layer - let's fetch the model
+	ok, avimodelIntf := objects.SharedAviGraphLister().Get(key)
+	var rest_ops []*utils.RestOp
+	var pools_to_delete []utils.NamespaceName
+	var pgs_to_delete []utils.NamespaceName
+	var https_to_delete []utils.NamespaceName
+	avimodel := avimodelIntf.(*nodes.AviObjectGraph)
+	if !ok {
+		utils.AviLog.Info.Printf("No model found for the key %s", key)
+	}
+	// Order would be this: 1. Pools 2. PGs  3. HTTPPolicies. 4. VS
+	// Get the pools
+	gatewayNs, vsName := utils.ExtractGatewayNamespace(key)
+	pools := avimodel.GetAviPools()
+	cache := utils.SharedAviObjCache()
+	vsKey := utils.NamespaceName{Namespace: gatewayNs, Name: vsName}
+	vs_cache, ok := cache.VsCache.AviCacheGet(vsKey)
+	poolGroups := avimodel.GetAviPoolGroups()
+	HTTPPolicies := avimodel.GetAviHttpPolicies()
+	//Decide pool create/delete/update
+	vs_cache_obj, ok := vs_cache.(*utils.AviVsCache)
+	if ok {
+		utils.AviLog.Info.Printf("The VS object was found in the cache: %v", utils.Stringify(vs_cache_obj))
+		pools_to_delete, rest_ops = PoolCU(pools, vs_cache_obj.PoolKeyCollection, gatewayNs, rest_ops)
+		pgs_to_delete, rest_ops = PoolGroupCU(poolGroups, vs_cache_obj.PGKeyCollection, gatewayNs, rest_ops)
+		https_to_delete, rest_ops = HTTPPolicyCU(HTTPPolicies, vs_cache_obj.HTTPKeyCollection, gatewayNs, rest_ops)
+	} else {
+		_, rest_ops = PoolCU(pools, nil, gatewayNs, rest_ops)
+		_, rest_ops = PoolGroupCU(poolGroups, nil, gatewayNs, rest_ops)
+		_, rest_ops = HTTPPolicyCU(HTTPPolicies, nil, gatewayNs, rest_ops)
+	}
+	aviVSes := avimodel.GetAviVS()
+	if len(aviVSes) != 1 {
+		utils.AviLog.Error.Fatalf("More than one VS received. One Gateway should always map to one VS")
+		return
+	}
+	// There should be only one VS to parse per model
+	if ok {
+		// The VS cache was found
+		vs_cache_obj, _ := vs_cache.(*utils.AviVsCache)
+		// Cache found. Let's compare the checksums
+		if vs_cache_obj.CloudConfigCksum == fmt.Sprint(aviVSes[0].GetCheckSum()) {
+			utils.AviLog.Info.Printf("The checksums are same for VS %s, not doing anything", vs_cache_obj.Name)
+		} else {
+			utils.AviLog.Info.Printf("The stored checksum for VS is %v, and the obtained checksum for VS is: %v", vs_cache_obj.CloudConfigCksum, fmt.Sprint(aviVSes[0].GetCheckSum()))
+			// The checksums are different, so it should be a PUT call.
+			restOp := AviVsBuild(aviVSes[0], HTTPPolicies, utils.RestPut, vs_cache_obj)
+			rest_ops = append(rest_ops, restOp...)
+		}
+	} else {
+		// The cache was not found - it's a POST call.
+		restOp := AviVsBuild(aviVSes[0], HTTPPolicies, utils.RestPost, nil)
+		rest_ops = append(rest_ops, restOp...)
+	}
+	// Let's populate all the DELETE entries
+	rest_ops = HTTPPolicyDelete(https_to_delete, gatewayNs, rest_ops)
+	rest_ops = PoolGroupDelete(pgs_to_delete, gatewayNs, rest_ops)
+	rest_ops = PoolDelete(pools_to_delete, gatewayNs, rest_ops)
+
+	avi_rest_client_pool := utils.SharedAVIClients()
+	aviclient := avi_rest_client_pool.AviClient[0]
+	utils.AviLog.Info.Printf("The list of REST OPS: %s", utils.Stringify(rest_ops))
+	err := avi_rest_client_pool.AviRestOperate(aviclient, rest_ops)
+	if err != nil {
+		utils.AviLog.Info.Fatalf("There was an error sending the macro %s", err)
+
+		// Iterate over rest_ops in reverse and delete created objs
+		for i := len(rest_ops) - 1; i >= 0; i-- {
+			if rest_ops[i].Err == nil {
+				resp_arr, ok := rest_ops[i].Response.([]interface{})
+				if !ok {
+					utils.AviLog.Warning.Printf("Invalid resp type for rest_op %v", rest_ops[i])
+					continue
+				}
+				resp, ok := resp_arr[0].(map[string]interface{})
+				if ok {
+					uuid, ok := resp["uuid"].(string)
+					if !ok {
+						utils.AviLog.Warning.Printf("Invalid resp type for uuid %v",
+							resp)
+						continue
+					}
+					url := utils.AviModelToUrl(rest_ops[i].Model) + "/" + uuid
+					err := aviclient.AviSession.Delete(url)
+					if err != nil {
+						utils.AviLog.Warning.Printf("Error %v deleting url %v", err, url)
+					} else {
+						utils.AviLog.Info.Printf("Success deleting url %v", url)
+					}
+				} else {
+					utils.AviLog.Warning.Printf("Invalid resp for rest_op %v", rest_ops[i])
+				}
+			}
+		}
+	} else {
+		// Add to local obj caches
+		for _, rest_op := range rest_ops {
+			if rest_op.Err == nil && (rest_op.Method == utils.RestPost || rest_op.Method == utils.RestPut) {
+				if rest_op.Model == "Pool" {
+					AviPoolCacheAdd(cache, rest_op, vsKey)
+				} else if rest_op.Model == "VirtualService" {
+					AviVsCacheAdd(cache, rest_op)
+				} else if rest_op.Model == "PoolGroup" {
+					AviPGCacheAdd(cache, rest_op, vsKey)
+				} else if rest_op.Model == "HTTPPolicySet" {
+					AviHTTPPolicyCacheAdd(cache, rest_op, vsKey)
+				}
+			} else {
+				if rest_op.Model == "Pool" {
+					AviPoolCacheDel(cache, rest_op, vsKey)
+				} else if rest_op.Model == "VirtualService" {
+					AviVsCacheDel(cache.VsCache, rest_op)
+				} else if rest_op.Model == "PoolGroup" {
+					AviPGCacheDel(cache, rest_op, vsKey)
+				} else if rest_op.Model == "HTTPPolicySet" {
+					AviHTTPCacheDel(cache, rest_op, vsKey)
+				}
+			}
+		}
+
+	}
+}
+
+func PoolDelete(pools_to_delete []utils.NamespaceName, gatewayNs string, rest_ops []*utils.RestOp) []*utils.RestOp {
+	cache := utils.SharedAviObjCache()
+	for _, del_pool := range pools_to_delete {
+		// fetch trhe pool uuid from cache
+		pool_key := utils.NamespaceName{Namespace: gatewayNs, Name: del_pool.Name}
+		pool_cache, ok := cache.PoolCache.AviCacheGet(pool_key)
+		if ok {
+			pool_cache_obj, _ := pool_cache.(*utils.AviPoolCache)
+			restOp := AviPoolDel(pool_cache_obj.Uuid, gatewayNs)
+			restOp.ObjName = del_pool.Name
+			rest_ops = append(rest_ops, restOp)
+		}
+	}
+	return rest_ops
+}
+
+func HTTPPolicyDelete(https_to_delete []utils.NamespaceName, gatewayNs string, rest_ops []*utils.RestOp) []*utils.RestOp {
+	cache := utils.SharedAviObjCache()
+	for _, del_http := range https_to_delete {
+		// fetch trhe pool uuid from cache
+		http_key := utils.NamespaceName{Namespace: gatewayNs, Name: del_http.Name}
+		http_cache, ok := cache.HTTPCache.AviCacheGet(http_key)
+		if ok {
+			http_cache_obj, _ := http_cache.(*utils.AviHTTPCache)
+			restOp := AviHttpPolicyDel(http_cache_obj.Uuid, gatewayNs)
+			restOp.ObjName = del_http.Name
+			rest_ops = append(rest_ops, restOp)
+		}
+	}
+	return rest_ops
+}
+
+func PoolGroupDelete(pgs_to_delete []utils.NamespaceName, gatewayNs string, rest_ops []*utils.RestOp) []*utils.RestOp {
+	cache := utils.SharedAviObjCache()
+	utils.AviLog.Info.Printf("About to delete the PGs %s", pgs_to_delete)
+	for _, del_pg := range pgs_to_delete {
+		// fetch trhe pool uuid from cache
+		pg_key := utils.NamespaceName{Namespace: gatewayNs, Name: del_pg.Name}
+		pg_cache, ok := cache.PgCache.AviCacheGet(pg_key)
+		if ok {
+			pg_cache_obj, _ := pg_cache.(*utils.AviPGCache)
+			restOp := AviPGDel(pg_cache_obj.Uuid, gatewayNs)
+			restOp.ObjName = del_pg.Name
+			rest_ops = append(rest_ops, restOp)
+		}
+	}
+	return rest_ops
+}
+
+func PoolCU(pool_nodes []*nodes.AviPoolNode, cache_pool_nodes []utils.NamespaceName, gatewayNs string, rest_ops []*utils.RestOp) ([]utils.NamespaceName, []*utils.RestOp) {
+	// Default is POST
+	if cache_pool_nodes != nil {
+		cache := utils.SharedAviObjCache()
+		for _, pool := range pool_nodes {
+			// check in the pool cache to see if this pool exists in AVI
+			pool_key := utils.NamespaceName{Namespace: gatewayNs, Name: pool.Name}
+			found := Contains(cache_pool_nodes, pool_key)
+			if found {
+				cache_pool_nodes = Remove(cache_pool_nodes, pool_key)
+				utils.AviLog.Info.Printf("The cache pool nodes are: %v", cache_pool_nodes)
+				pool_cache, ok := cache.PoolCache.AviCacheGet(pool_key)
+				if ok {
+					pool_cache_obj, _ := pool_cache.(*utils.AviPoolCache)
+					// Cache found. Let's compare the checksums
+					if pool_cache_obj.CloudConfigCksum == fmt.Sprint(pool.GetCheckSum()) {
+						utils.AviLog.Info.Printf("The checksums are same for Pool %s, not doing anything", pool.Name)
+					} else {
+						// The checksums are different, so it should be a PUT call.
+						restOp := AviPoolBuild(pool, pool_cache_obj)
+						rest_ops = append(rest_ops, restOp)
+					}
+				}
+			} else {
+				// Not found - it should be a POST call.
+				restOp := AviPoolBuild(pool, nil)
+				rest_ops = append(rest_ops, restOp)
+			}
+
+		}
+	} else {
+		// Everything is a POST call
+		for _, pool := range pool_nodes {
+			restOp := AviPoolBuild(pool, nil)
+			rest_ops = append(rest_ops, restOp)
+		}
+
+	}
+	utils.AviLog.Info.Printf("The POOLS rest_op is %s", utils.Stringify(rest_ops))
+	utils.AviLog.Info.Printf("The POOLs to be deleted are: %s", cache_pool_nodes)
+	return cache_pool_nodes, rest_ops
+}
+
+func PoolGroupCU(pg_nodes []*nodes.AviPoolGroupNode, cache_pg_nodes []utils.NamespaceName, gatewayNs string, rest_ops []*utils.RestOp) ([]utils.NamespaceName, []*utils.RestOp) {
+	// Default is POST
+	if cache_pg_nodes != nil {
+		cache := utils.SharedAviObjCache()
+		for _, pg := range pg_nodes {
+			pg_key := utils.NamespaceName{Namespace: gatewayNs, Name: pg.Name}
+			found := Contains(cache_pg_nodes, pg_key)
+			if found {
+				cache_pg_nodes = Remove(cache_pg_nodes, pg_key)
+				pg_cache, ok := cache.PgCache.AviCacheGet(pg_key)
+				if ok {
+					pg_cache_obj, _ := pg_cache.(*utils.AviPGCache)
+					// Cache found. Let's compare the checksums
+					if pg_cache_obj.CloudConfigCksum == fmt.Sprint(pg.GetCheckSum()) {
+						utils.AviLog.Info.Printf("The checksums are same for PG %s, not doing anything", pg_cache_obj.Name)
+					} else {
+						// The checksums are different, so it should be a PUT call.
+						restOp := AviPoolGroupBuild(pg, pg_cache_obj)
+						rest_ops = append(rest_ops, restOp)
+					}
+				}
+			} else {
+				// Not found - it should be a POST call.
+				restOp := AviPoolGroupBuild(pg, nil)
+				rest_ops = append(rest_ops, restOp)
+			}
+
+		}
+	} else {
+		// Everything is a POST call
+		for _, pg := range pg_nodes {
+			restOp := AviPoolGroupBuild(pg, nil)
+			rest_ops = append(rest_ops, restOp)
+		}
+
+	}
+	utils.AviLog.Info.Printf("The PGs rest_op is %s", utils.Stringify(rest_ops))
+	utils.AviLog.Info.Printf("The PGs to be deleted are: %s", cache_pg_nodes)
+	return cache_pg_nodes, rest_ops
+}
+
+func HTTPPolicyCU(http_nodes []*nodes.AviHttpPolicySetNode, cache_http_nodes []utils.NamespaceName, gatewayNs string, rest_ops []*utils.RestOp) ([]utils.NamespaceName, []*utils.RestOp) {
+	// Default is POST
+	if cache_http_nodes != nil {
+		cache := utils.SharedAviObjCache()
+		for _, http := range http_nodes {
+			http_key := utils.NamespaceName{Namespace: gatewayNs, Name: http.Name}
+			found := Contains(cache_http_nodes, http_key)
+			if found {
+				http_cache, ok := cache.HTTPCache.AviCacheGet(http_key)
+				if ok {
+					cache_http_nodes = Remove(cache_http_nodes, http_key)
+					http_cache_obj, _ := http_cache.(*utils.AviHTTPCache)
+					// Cache found. Let's compare the checksums
+					if http_cache_obj.CloudConfigCksum == fmt.Sprint(http.GetCheckSum()) {
+						utils.AviLog.Info.Printf("The checksums are same for HTTP cache obj %s, not doing anything", http_cache_obj.Name)
+					} else {
+						// The checksums are different, so it should be a PUT call.
+						restOp := AviHttpPSBuild(http, http_cache_obj)
+						rest_ops = append(rest_ops, restOp)
+					}
+				}
+			} else {
+				// Not found - it should be a POST call.
+				restOp := AviHttpPSBuild(http, nil)
+				rest_ops = append(rest_ops, restOp)
+			}
+
+		}
+	} else {
+		// Everything is a POST call
+		for _, http := range http_nodes {
+			restOp := AviHttpPSBuild(http, nil)
+			rest_ops = append(rest_ops, restOp)
+		}
+
+	}
+	utils.AviLog.Info.Printf("The HTTP Policies rest_op is %s", utils.Stringify(rest_ops))
+	return cache_http_nodes, rest_ops
+}
+
+func Contains(s []utils.NamespaceName, e utils.NamespaceName) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+func Remove(s []utils.NamespaceName, r utils.NamespaceName) []utils.NamespaceName {
+	for i, v := range s {
+		if v == r {
+			return append(s[:i], s[i+1:]...)
+		}
+	}
+	return s
+}

--- a/pkg/utils/avi_obj_cache.go
+++ b/pkg/utils/avi_obj_cache.go
@@ -207,8 +207,6 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient,
 						}
 					}
 				}
-				//vsvip_intf, _ := vs["vip"].(map[string]interface{})
-				AviLog.Info.Printf("MY GOD :%v", vs["vip"])
 				var tenant string
 				url, err := url.Parse(vs["tenant_ref"].(string))
 				if err != nil {

--- a/pkg/utils/avi_rest_utils.go
+++ b/pkg/utils/avi_rest_utils.go
@@ -41,7 +41,7 @@ func SharedAVIClients() *AviRestClientPool {
 		AviLog.Error.Panic(`AVI controller information missing. Update them in kubernetes secret or via environment variables.`)
 	}
 	clientonce.Do(func() {
-		AviClientInstance, _ = NewAviRestClientPool(NumWorkers,
+		AviClientInstance, _ = NewAviRestClientPool(NumWorkersGraph,
 			ctrlIpAddress, ctrlUsername, ctrlPassword)
 	})
 	return AviClientInstance

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -17,8 +17,8 @@ package utils
 const (
 	GraphLayer            = "GraphLayer"
 	ObjectIngestionLayer  = "ObjectIngestionLayer"
-	LeastConnection       = "LEAST_CONN"
+	LeastConnection       = "LB_ALGORITHM_LEAST_CONNECTIONS"
 	RandomConnection      = "RANDOM_CONN"
 	PassthroughConnection = "PASSTHROUGH_CONN"
-	RoundRobinConnection  = "ROUND_ROBIN_CONN"
+	RoundRobinConnection  = "LB_ALGORITHM_ROUND_ROBIN"
 )

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -15,6 +15,10 @@
 package utils
 
 const (
-	GraphLayer           = "GraphLayer"
-	ObjectIngestionLayer = "ObjectIngestionLayer"
+	GraphLayer            = "GraphLayer"
+	ObjectIngestionLayer  = "ObjectIngestionLayer"
+	LeastConnection       = "LEAST_CONN"
+	RandomConnection      = "RANDOM_CONN"
+	PassthroughConnection = "PASSTHROUGH_CONN"
+	RoundRobinConnection  = "ROUND_ROBIN_CONN"
 )

--- a/pkg/utils/queue.go
+++ b/pkg/utils/queue.go
@@ -26,7 +26,7 @@ import (
 
 var queuewrapper sync.Once
 var queueInstance *WorkQueueWrapper
-var fixedQueues = [...]WorkerQueue{WorkerQueue{NumWorkers: NumWorkers, workqueueName: ObjectIngestionLayer}, WorkerQueue{NumWorkers: NumWorkers, workqueueName: GraphLayer}}
+var fixedQueues = [...]WorkerQueue{WorkerQueue{NumWorkers: NumWorkersIngestion, workqueueName: ObjectIngestionLayer}, WorkerQueue{NumWorkers: NumWorkersGraph, workqueueName: GraphLayer}}
 
 type WorkQueueWrapper struct {
 	// This struct should manage a set of WorkerQueues for the various layers

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -28,7 +28,7 @@ const (
 	UpdateEv            EvType = "UPDATE"
 	DeleteEv            EvType = "DELETE"
 	NumWorkersIngestion uint32 = 1
-	NumWorkersGraph     uint32 = 1
+	NumWorkersGraph     uint32 = 2
 )
 
 const (

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -19,17 +19,16 @@ import (
 
 	avimodels "github.com/avinetworks/sdk/go/models"
 	coreinformers "k8s.io/client-go/informers/core/v1"
-	extinformers "k8s.io/client-go/informers/extensions/v1beta1"
 )
 
 type EvType string
 
-const NumWorkers uint32 = 2
-
 const (
-	CreateEv EvType = "CREATE"
-	UpdateEv EvType = "UPDATE"
-	DeleteEv EvType = "DELETE"
+	CreateEv            EvType = "CREATE"
+	UpdateEv            EvType = "UPDATE"
+	DeleteEv            EvType = "DELETE"
+	NumWorkersIngestion uint32 = 1
+	NumWorkersGraph     uint32 = 1
 )
 
 const (
@@ -44,7 +43,7 @@ const (
 type Informers struct {
 	ServiceInformer coreinformers.ServiceInformer
 	EpInformer      coreinformers.EndpointsInformer
-	IngInformer     extinformers.IngressInformer
+	PodInformer     coreinformers.PodInformer
 }
 
 type AviRestObjMacro struct {
@@ -72,6 +71,7 @@ type RestOp struct {
 	Err      error
 	Model    string
 	Version  string
+	ObjName  string // Optional field - right only to be used for delete.
 }
 
 type ServiceMetadataObj struct {
@@ -156,11 +156,15 @@ type AviPoolCache struct {
 }
 
 type AviVsCache struct {
-	Name             string
-	Tenant           string
-	Uuid             string
-	ServiceMetadata  ServiceMetadataObj
-	CloudConfigCksum string
+	Name              string
+	Tenant            string
+	Uuid              string
+	Vip               []*avimodels.Vip
+	ServiceMetadata   ServiceMetadataObj
+	CloudConfigCksum  string
+	PGKeyCollection   []NamespaceName
+	PoolKeyCollection []NamespaceName
+	HTTPKeyCollection []NamespaceName
 }
 
 type AviPGCache struct {
@@ -168,6 +172,13 @@ type AviPGCache struct {
 	Tenant           string
 	Uuid             string
 	ServiceMetadata  ServiceMetadataObj
+	CloudConfigCksum string
+}
+
+type AviHTTPCache struct {
+	Name             string
+	Tenant           string
+	Uuid             string
 	CloudConfigCksum string
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -167,4 +168,20 @@ func ExtractGatewayNamespace(key string) (string, string) {
 		return segments[0], segments[1]
 	}
 	return "", ""
+}
+
+func HasElem(s interface{}, elem interface{}) bool {
+	arrV := reflect.ValueOf(s)
+
+	if arrV.Kind() == reflect.Slice {
+		for i := 0; i < arrV.Len(); i++ {
+			// XXX - panics if slice element points to an unexported struct field
+			// see https://golang.org/pkg/reflect/#Value.Interface
+			if arrV.Index(i).Interface() == elem {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -142,6 +142,7 @@ func NewInformers(cs *kubernetes.Clientset) *Informers {
 		informerInstance = &Informers{
 			ServiceInformer: kubeInformerFactory.Core().V1().Services(),
 			EpInformer:      kubeInformerFactory.Core().V1().Endpoints(),
+			PodInformer:     kubeInformerFactory.Core().V1().Pods(),
 		}
 	})
 	return informerInstance
@@ -158,4 +159,12 @@ func GetInformers() *Informers {
 func Stringify(serialize interface{}) string {
 	json_marshalled, _ := json.Marshal(serialize)
 	return string(json_marshalled)
+}
+
+func ExtractGatewayNamespace(key string) (string, string) {
+	segments := strings.Split(key, "/")
+	if len(segments) == 2 {
+		return segments[0], segments[1]
+	}
+	return "", ""
 }


### PR DESCRIPTION
This PR proposes changes that would do the following:

- Introduce the Destination Rule object.
- Support basic Destination Rule functionality w.r.t Pool algorithm
selection. (needs more testing).
- As a consequence supports the subsets.
- Introduces the REST layer that dequeues data from the graph layer
- Introduces a caching mechanism (that needs further tests) to ensure
that we are able to successfully decide on a PUT/POST/DELETE call in
the REST layer (again needs more tests).
- Ensures that the broken is fixed broadly as a principle.