### PR TITLE
Test cases for avi_model_nodes and istio_model_rel

### DIFF
--- a/pkg/istio/nodes/avi_model_nodes_test.go
+++ b/pkg/istio/nodes/avi_model_nodes_test.go
@@ -1,0 +1,125 @@
+/*
+* [2013] - [2019] Avi Networks Incorporated
+* All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package nodes
+
+import (
+	"testing"
+
+	avimodels "github.com/avinetworks/sdk/go/models"
+	"github.com/onsi/gomega"
+)
+
+var aviVSNode *AviVsNode
+var aviVSNode1 *AviVsNode
+var aviVSNode2 *AviVsNode
+var aviPGNode *AviPoolGroupNode
+var aviPGNode1 *AviPoolGroupNode
+var aviPGNode2 *AviPoolGroupNode
+var aviPN *AviPoolNode
+var aviPN1 *AviPoolNode
+var aviPN2 *AviPoolNode
+var aviObjGraph *AviObjectGraph
+
+func checksumSetup() {
+	// setting up the AviVsNode the AviPoolGroupNode and the AviPoolNode variables
+	svcMdObj := ServiceMetadataObj{`json:"crud_hash_key"`}
+	aviPortHP := AviPortHostProtocol{Port: 80, Protocol: "TCP", Hosts: []string{"10.52.58.82"}}
+	vsNode := AviVsNode{Name: "fanout-ingress.default.avi.internal", Tenant: "default", ServiceMetadata: svcMdObj, ApplicationProfile: "System-HTTP", NetworkProfile: "System-TCP-Proxy", PortProto: []AviPortHostProtocol{aviPortHP}, DefaultPool: "", EastWest: true, CloudConfigCksum: 0, DefaultPoolGroup: "fanout-ingress.default.avi.internal--v2*-aviroute-poolgroup-80-tcp", HTTPChecksum: 0}
+	vsNode1 := AviVsNode{Name: "fanout-ingress.default.avi.internal", Tenant: "default", ServiceMetadata: svcMdObj, ApplicationProfile: "System-HTTP", NetworkProfile: "System-TCP-Proxy", PortProto: []AviPortHostProtocol{aviPortHP}, DefaultPool: "", EastWest: true, CloudConfigCksum: 0, DefaultPoolGroup: "fanout-ingress.default.avi.internal--v2*-aviroute-poolgroup-80-tcp", HTTPChecksum: 0}
+	vsNode2 := AviVsNode{Name: "ingress-nginx.ingress-nginx.avi.internal", Tenant: "ingress-nginx", ServiceMetadata: svcMdObj, ApplicationProfile: "System-L4-Application", NetworkProfile: "System-TCP-Proxy", PortProto: []AviPortHostProtocol{aviPortHP}, DefaultPool: "", EastWest: true, CloudConfigCksum: 0, DefaultPoolGroup: "ingress-nginx-poolgroup-https-tcp", HTTPChecksum: 0}
+	var irms isRouteMatch_PathSpecifier
+	matchList := MatchCriteria{Name: "", Criteria: "", PathSpecifier: irms}
+	var model *avimodels.PoolGroupMember
+	pg := AviPoolGroupNode{Name: "fanout-ingress.default.avi.internal--v2*-aviroute-poolgroup-80-tcp", Tenant: "default", ServiceMetadata: svcMdObj, CloudConfigCksum: 0, RuleChecksum: 0, Members: []*avimodels.PoolGroupMember{model}, MatchList: []MatchCriteria{matchList}}
+	pg1 := AviPoolGroupNode{Name: "fanout-ingress.default.avi.internal--v2*-aviroute-poolgroup-80-tcp", Tenant: "default", ServiceMetadata: svcMdObj, CloudConfigCksum: 0, RuleChecksum: 0, Members: []*avimodels.PoolGroupMember{model}, MatchList: []MatchCriteria{matchList}}
+	pg2 := AviPoolGroupNode{Name: " ingress-nginx-poolgroup-https-tcp", Tenant: "ingress-nginx", ServiceMetadata: svcMdObj, CloudConfigCksum: 0, RuleChecksum: 0, Members: []*avimodels.PoolGroupMember{model}, MatchList: []MatchCriteria{matchList}}
+	var ip avimodels.IPAddr
+	server := AviPoolMetaServer{Ip: ip, ServerNode: "fanout-ingress.default.avi.internal"}
+	poolNode := AviPoolNode{Name: "fanout-ingress.default.avi.internal--*-aviroute-pool-8080-tcp", Tenant: "default", ServiceMetadata: svcMdObj, CloudConfigCksum: 0, Port: 80, PortName: "HTTP", Servers: []AviPoolMetaServer{server}, Protocol: "HTTP", LbAlgorithm: "Least Connections"}
+	poolNode1 := AviPoolNode{Name: "fanout-ingress.default.avi.internal--*-aviroute-pool-8080-tcp", Tenant: "default", ServiceMetadata: svcMdObj, CloudConfigCksum: 0, Port: 80, PortName: "HTTP", Servers: []AviPoolMetaServer{server}, Protocol: "HTTP", LbAlgorithm: "Least Connections"}
+	poolNode2 := AviPoolNode{Name: "ingress-nginx-pool-https-tcp", Tenant: "ingress-nginx", ServiceMetadata: svcMdObj, CloudConfigCksum: 0, Port: 80, PortName: "HTTP", Servers: []AviPoolMetaServer{server}, Protocol: "HTTP", LbAlgorithm: "Least Connections"}
+	aviVSNode = &vsNode
+	aviVSNode1 = &vsNode1
+	aviVSNode2 = &vsNode2
+	aviPGNode = &pg
+	aviPGNode1 = &pg1
+	aviPGNode2 = &pg2
+	aviPN = &poolNode
+	aviPN1 = &poolNode1
+	aviPN2 = &poolNode2
+
+	// Setting up a new Avi Object Graph
+	aviObjGraph = NewAviObjectGraph()
+	aviObjGraph.AddModelNode(aviVSNode)
+	aviObjGraph.AddModelNode(aviVSNode1)
+	aviObjGraph.AddModelNode(aviPGNode)
+	aviObjGraph.AddModelNode(aviPGNode1)
+	aviObjGraph.AddModelNode(aviPN)
+	aviObjGraph.AddModelNode(aviPN1)
+
+}
+
+func TestGetCheckSum(t *testing.T) {
+	checksumSetup()
+	g := gomega.NewGomegaWithT(t)
+
+	// Setting the checksum value for the AviVsNode, the AviPoolGroupNode and the AviPoolNode
+	for _, VSnode := range aviObjGraph.GetAviVS() {
+		VSnode.CalculateCheckSum()
+	}
+	for _, PGNode := range aviObjGraph.GetAviPoolGroups() {
+		PGNode.CalculateCheckSum()
+	}
+	for _, PoolNode := range aviObjGraph.GetAviPools() {
+		PoolNode.CalculateCheckSum()
+	}
+
+	// Testing the GetCheckSum() method for the AviVsNode, AviPoolGroupNode and for the AviPoolNode
+
+	// Testing the GetChecksum() method for different avi nodes which have the same values
+	vsNode := aviObjGraph.GetAviVS()
+	g.Expect(vsNode[0].GetCheckSum()).To(gomega.Equal(vsNode[1].GetCheckSum()))
+	pgNode := aviObjGraph.GetAviPoolGroups()
+	g.Expect(pgNode[0].GetCheckSum()).To(gomega.Equal(pgNode[1].GetCheckSum()))
+	poolNode := aviObjGraph.GetAviPools()
+	g.Expect(poolNode[0].GetCheckSum()).To(gomega.Equal(poolNode[1].GetCheckSum()))
+
+	// Testing the GetCheckSum() for different avi nodes which have different values
+	for _, VSNode := range aviObjGraph.GetAviVS() {
+		g.Expect(aviVSNode2.GetCheckSum()).NotTo(gomega.Equal(VSNode.GetCheckSum()))
+	}
+	for _, PGNode := range aviObjGraph.GetAviPoolGroups() {
+		g.Expect(aviPGNode2.GetCheckSum()).NotTo(gomega.Equal(PGNode.GetCheckSum()))
+	}
+	for _, PoolNode := range aviObjGraph.GetAviPools() {
+		g.Expect(aviPN2.GetCheckSum()).NotTo(gomega.Equal(PoolNode.GetCheckSum()))
+	}
+}
+
+func TestMatchCriteriaMethods(t *testing.T) {
+	var irmps isRouteMatch_PathSpecifier
+	matchList := MatchCriteria{Name: "", Criteria: "", PathSpecifier: irmps}
+	m := &matchList
+	g := gomega.NewGomegaWithT(t)
+	g.Expect(m.GetPathSpecifier()).To(gomega.BeNil())
+	g.Expect(matchList.PathSpecifier).To(gomega.BeNil())
+	// Testing if the GetPath() method returns an empty string since the path variable has not been set
+	g.Expect(m.GetPath()).To(gomega.Equal(""))
+	// Testing if the GetPrefix() method retiurns an empty string since the Prefix variable has not been set
+	g.Expect(m.GetPrefix()).To(gomega.Equal(""))
+	// Testing if the GetRegex() method returns an empty string since the Regex variable has not been set
+	g.Expect(m.GetRegex()).To(gomega.Equal(""))
+
+}

--- a/pkg/istio/nodes/avi_model_nodes_test.go
+++ b/pkg/istio/nodes/avi_model_nodes_test.go
@@ -62,6 +62,7 @@ func checksumSetup() {
 
 	// Setting up a new Avi Object Graph
 	aviObjGraph = NewAviObjectGraph()
+	// Adding nodes to the Avi Object Graph
 	aviObjGraph.AddModelNode(aviVSNode)
 	aviObjGraph.AddModelNode(aviVSNode1)
 	aviObjGraph.AddModelNode(aviPGNode)

--- a/pkg/istio/nodes/drain_test.go
+++ b/pkg/istio/nodes/drain_test.go
@@ -19,11 +19,14 @@ import (
 	"testing"
 
 	"github.com/avinetworks/servicemesh/pkg/istio/objects"
+	istio_objs "github.com/avinetworks/servicemesh/pkg/istio/objects"
 	"github.com/onsi/gomega"
 )
 
 var vsLister *objects.VirtualServiceLister
 var gwLister *objects.GatewayLister
+
+var drLister *objects.DRLister
 
 func TestMain(m *testing.M) {
 	setup()
@@ -31,6 +34,7 @@ func TestMain(m *testing.M) {
 	// If clean ups are needed later.
 	//shutdown()
 	os.Exit(code)
+
 }
 
 func setup() {
@@ -52,6 +56,7 @@ func setup() {
 		obj_value *objects.IstioObject
 	}{
 		{objects.MakeGateway("default", "gw_1", 1)},
+		{objects.MakeGateway("default", "gw_2", 1)},
 	}
 	for _, pt := range sampleGWValues {
 		gwLister.Gateway(pt.obj_value.ConfigMeta.Namespace).Update(pt.obj_value)
@@ -67,6 +72,190 @@ func TestVSServiceCreate(t *testing.T) {
 	g.Expect(svcs).To(gomega.Equal(expectedSvcs))
 	gateways = SvcToGateway("reviews", "default")
 	g.Expect(gateways).To(gomega.ContainElement("ns/gw1"))
+
+	gateways = VSToGateway("vs_2", "default")
+	g.Expect(gateways).To(gomega.ContainElement("ns/gw1"))
+	svcs = vsLister.VirtualService("default").GetVSToSVC("vs_2")
+	expectedSvcs = []string{"reviews", "reviews.prod"}
+	g.Expect(svcs).To(gomega.Equal(expectedSvcs))
+	gateways = SvcToGateway("reviews", "default")
+	g.Expect(gateways).To(gomega.ContainElement("ns/gw1"))
+
+	//Testing whether values for a VS which was not created get returned correctly
+	gateways = VSToGateway("vs_5", "default")
+	g.Expect(gateways).To(gomega.Equal([]string{}))
+	svcs = vsLister.VirtualService("default").GetVSToSVC("vs_5")
+	g.Expect(svcs).To(gomega.Equal([]string{}))
+	gateways = SvcToGateway("", "default")
+	g.Expect(gateways).To(gomega.BeNil())
+
+}
+
+func TestVSToGateway(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	// get the associated gateways to the corresponding VS from the VSToGateway() method
+	gateways := VSToGateway("vs_1", "default")
+	v := vsLister.VirtualService("default")
+
+	// get the gateways associated with the corresponding VS using the GetGatewaysForVS() method
+	flag, gws := v.GetGatewaysForVS("vs_1")
+	if flag {
+		for _, gateway := range gws {
+			// range over all the gateways obtained from the GetGatewaysForVS() method and check whether each of those methods are in the gateways variable obtained from the VSToGateway() method
+			g.Expect(gateways).To(gomega.ContainElement(gateway))
+
+		}
+	} else {
+		t.Error("Error occurred")
+	}
+
+	g.Expect(len(gateways)).To(gomega.Equal(1))
+
+	// Testing if an empty string array is returned by the VSToGateway() method when we pass a VS which has not been created
+	gateways = VSToGateway("vs_5", "default")
+	check, gws2 := v.GetGatewaysForVS("vs_5")
+	if !check {
+		g.Expect(gateways).To(gomega.Equal(gws2))
+	}
+
+}
+
+func TestGetGatewayNamespace(t *testing.T) {
+	// Testing the GetGatewayNamespace() method for individual gateways
+	gatewaynsTest := GetGatewayNamespace("default", "gw_1")
+	g := gomega.NewGomegaWithT(t)
+	g.Expect(gatewaynsTest).To(gomega.Equal("default"))
+
+	gatewaynsTest2 := GetGatewayNamespace("default", "istio-system/gw_2")
+	g.Expect(gatewaynsTest2).To(gomega.Equal("istio-system"))
+
+	// No namespace should be associated with this gateway as this gateway has not been created
+	gatewaysnsTest3 := GetGatewayNamespace("", "gw_3")
+	g.Expect(gatewaysnsTest3).To(gomega.Equal(""))
+
+	// Testing the GetGatewayNamespace() method when iterating over all the gateways
+	allGateways := gwLister.GetAllGateways()
+	for gwKey, gwValue := range allGateways {
+		for gw := range gwValue {
+			g.Expect(GetGatewayNamespace(gwKey, gw)).To(gomega.Equal("default"))
+
+		}
+	}
+}
+
+func TestSvcToGateway(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	v := vsLister.VirtualService("default")
+	svcs := v.GetVSToSVC("vs_1")
+
+	for _, service := range svcs {
+		gateways := SvcToGateway(service, "default")
+		flag, vs := istio_objs.SharedSvcLister().Service("default").GetSvcToVS(service)
+		if flag {
+			for _, vsName := range vs {
+				check, gateway := v.GetGatewaysForVS(vsName)
+				if check {
+					for _, gw := range gateway {
+						g.Expect(gateways).To(gomega.ContainElement(gw))
+					}
+				}
+			}
+		} else {
+			t.Error("Error occurred")
+		}
+	}
+
+	// Checking whether the SvcToGateway() method works correctly when a service which was not created is passed to the method
+	svcs = v.GetVSToSVC("vs_5")
+	if svcs == nil {
+		g.Expect(SvcToGateway("", "default")).To(gomega.BeNil())
+	} else {
+		for _, service := range svcs {
+			gateways := SvcToGateway(service, "default")
+			flag, vs := istio_objs.SharedSvcLister().Service("default").GetSvcToVS(service)
+			if flag {
+				for _, vsName := range vs {
+					check, gateway := v.GetGatewaysForVS(vsName)
+					if check {
+						for _, gw := range gateway {
+							g.Expect(gateways).To(gomega.ContainElement(gw))
+						}
+					}
+				}
+			} else {
+				t.Error("Error occurred")
+			}
+		}
+	}
+}
+
+func TestEPToGateway(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	v := vsLister.VirtualService("default")
+	svcs := v.GetVSToSVC("vs_1")
+
+	// Testing whether or not the EPToGateway() method works when we iterate over all the EP's and access the associated gateways
+	for _, ep := range svcs {
+		gateways := EPToGateway(ep, "default")
+		flag, vs := istio_objs.SharedSvcLister().Service("default").GetSvcToVS(ep)
+		if flag {
+			for _, vsName := range vs {
+				check, gateway := v.GetGatewaysForVS(vsName)
+				if check {
+					for _, gw := range gateway {
+						// Checking if each gateway(gw) element is in the gateways object obtained from the EPToGateway() method
+						g.Expect(gateways).To(gomega.ContainElement(gw))
+					}
+				}
+			}
+		} else {
+			// If there are no associated VS's to the Endpoint then there is an error
+			t.Error("Error occurred")
+		}
+	}
+
+	svcs = v.GetVSToSVC("vs_5")
+
+	if len(svcs) == 0 {
+		g.Expect(EPToGateway("", "default")).To(gomega.BeNil())
+	} else {
+		for _, ep := range svcs {
+			gateways := EPToGateway(ep, "default")
+			flag, vs := istio_objs.SharedSvcLister().Service("default").GetSvcToVS(ep)
+			if flag {
+				for _, vsName := range vs {
+					check, gateway := v.GetGatewaysForVS(vsName)
+					if check {
+						for _, gw := range gateway {
+							// Checking if each gateway(gw) element is in the gateways object obtained from the EPToGateway() method
+							g.Expect(gateways).To(gomega.ContainElement(gw))
+						}
+					}
+				}
+			} else {
+				// If there are no associated VS's to the Endpoint then there is an error
+				t.Error("Error occurred")
+			}
+		}
+	}
+}
+
+func TestGatewayChanges(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Checking whether or not a current Gateway is added/exists in the list of Gateways
+	gateways := DetectGatewayChanges("gw_1", "default")
+	g.Expect(gateways).To(gomega.ContainElement("gw_1"))
+
+	//Deleting a current Gateway and checking if the DetectGatewayChanges() method returns nil or not
+	v := gwLister.Gateway("default")
+	if v.Delete("gw_1") {
+		g.Expect(DetectGatewayChanges("gw_1", "default")).To(gomega.BeNil())
+	}
+
+	//Checking if the DetectGatewayChanges() method returns nil on checking if there is a Gateway which doesn't exist
+	gateways = DetectGatewayChanges("gw_3", "default")
+	g.Expect(gateways).To(gomega.BeNil())
 }
 
 func TestVSServiceDelete(t *testing.T) {
@@ -78,7 +267,26 @@ func TestVSServiceDelete(t *testing.T) {
 	svcs := vsLister.VirtualService("default").GetVSToSVC("vs_1")
 	// We don't expect the relationship to exist anymore.
 	g.Expect(len(svcs)).To(gomega.Equal(0))
+	gateways = SvcToGateway("reviews", "default")
+	g.Expect(len(gateways)).To(gomega.Equal(1))
+
+	vsLister.VirtualService("default").Delete("vs_2")
+	gateways = VSToGateway("vs_2", "default")
+	g.Expect(gateways).To(gomega.ContainElement("ns/gw1"))
+	svcs = vsLister.VirtualService("default").GetVSToSVC("vs_2")
+	g.Expect(len(svcs)).To(gomega.Equal(0))
 	// Now the service will not be able to trace to the gateway
 	gateways = SvcToGateway("reviews", "default")
 	g.Expect(len(gateways)).To(gomega.Equal(0))
+
+	// Testing whether or not the correct values are returned when one tries to delete a VS which has already been deleted
+	emptyStringArray := []string{}
+	vsLister.VirtualService("default").Delete("vs_2")
+	gateways = VSToGateway("vs_2", "default")
+	g.Expect(gateways).To(gomega.Equal(emptyStringArray))
+	svcs = vsLister.VirtualService("default").GetVSToSVC("vs_2")
+	g.Expect(len(svcs)).To(gomega.Equal(0))
+	gateways = SvcToGateway("reviews", "default")
+	g.Expect(len(gateways)).To(gomega.Equal(0))
+
 }

--- a/pkg/istio/nodes/drain_test.go
+++ b/pkg/istio/nodes/drain_test.go
@@ -189,6 +189,7 @@ func TestSvcToGateway(t *testing.T) {
 	}
 }
 
+// Testing endpoint to gateway
 func TestEPToGateway(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	v := vsLister.VirtualService("default")

--- a/pkg/istio/objects/destination_rule_test.go
+++ b/pkg/istio/objects/destination_rule_test.go
@@ -1,0 +1,94 @@
+/*
+* [2013] - [2018] Avi Networks Incorporated
+* All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package objects
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestGetDRObject(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	drLister = SharedDRLister()
+	drObj := Make("default", "dr_1", 1)
+	drObj1 := Make("default", "dr_2", 1)
+	drLister.DestinationRule("default").Update(drObj)
+	drLister.DestinationRule("default").Update(drObj1)
+	dr := drLister.DestinationRule("default").GetAllDRNameVers()
+	drList := []string{}
+	for key := range dr {
+		drList = append(drList, key)
+	}
+	g.Expect(drList).To(gomega.ContainElement("dr_1"))
+	g.Expect(len(drList)).To(gomega.Equal(2))
+}
+
+func TestGetDRListMisc(t *testing.T) {
+	drLister = SharedDRLister()
+	_, dr_obj := drLister.DestinationRule("default").Get("dr_1")
+	if dr_obj == nil || dr_obj.ConfigMeta.Name != "dr_1" && dr_obj.ConfigMeta.ResourceVersion != "1" {
+		t.Errorf("TestGetDRListMisc failed to get the expected object, obtained :%s", dr_obj.ConfigMeta.Name)
+	}
+	_, dr_obj = drLister.DestinationRule("default").Get("dr_2")
+	if dr_obj == nil || dr_obj.ConfigMeta.Name != "dr_2" && dr_obj.ConfigMeta.ResourceVersion != "1" {
+		t.Errorf("TestGetDRListMisc failed to get the expected object, obtained :%s", dr_obj.ConfigMeta.Name)
+	}
+
+	dr_objs := drLister.DestinationRule("default").List()
+	if len(dr_objs) != 2 {
+		t.Errorf("TestGetDRListMisc failed to get the expected object, obtained :%d", len(dr_objs))
+	}
+
+	drLister.DestinationRule("default").Delete("dr_2")
+
+	// After deleting one of the DR objects ("dr_2") the object should not be in the list
+	_, dr_obj = drLister.DestinationRule("default").Get("dr_2")
+	if dr_obj != nil {
+		t.Errorf("TestGetDRListMisc failed to gert the expected object, obtained: %s", dr_obj.ConfigMeta.Name)
+	}
+	dr_objs = drLister.DestinationRule("default").List()
+	// dr_2 has been deleted and hence the length of thr total number of dr objects must be 1
+	if len(dr_objs) != 1 {
+		t.Errorf("TestGetDRListMisc failed to get the expected object, obtained :%d", len(dr_objs))
+	}
+}
+
+func TestGetAllDRs(t *testing.T) {
+	drMap := drLister.GetAllDRs()
+	if len(drMap["default"]) != 1 {
+		t.Errorf("TestGetAllDRs failed to get the expected object, obtained :%s", (drMap["default"]))
+	}
+	if drMap["default"]["dr_1"] != "1" {
+		t.Errorf("TestGetAllDRs failed to get the expected object, obtained :%s", drMap["default"]["dr_1"])
+	}
+
+	// Adding additional objects to test the GetAllDRs() method
+	drObj := Make("default", "dr_2", 1)
+	drObj1 := Make("red", "dr_3", 1)
+	drLister.DestinationRule("default").Update(drObj)
+	drLister.DestinationRule("red").Update(drObj1)
+	drMap = drLister.GetAllDRs()
+
+	// After adding an additional DR object to the list in the default namespace, the length of all objects under the default namespace must be 2
+	if len(drMap["default"]) != 2 {
+		t.Errorf("TestGetAllDRs failed to get the expected object, obtained :%s", (drMap["default"]))
+	}
+
+	// After adding a DR object belonging to the red namespace, the length of all objects under the red namespace must be 1
+	if len(drMap["red"]) != 1 {
+		t.Errorf("TestGetAllDRs failed to get the expected object, obtained :%s", (drMap["red"]))
+	}
+}

--- a/pkg/istio/objects/destination_rule_test.go
+++ b/pkg/istio/objects/destination_rule_test.go
@@ -28,6 +28,7 @@ func TestGetDRObject(t *testing.T) {
 	drLister.DestinationRule("default").Update(drObj)
 	drLister.DestinationRule("default").Update(drObj1)
 	dr := drLister.DestinationRule("default").GetAllDRNameVers()
+	// Obtaining a list of all the DR objects
 	drList := []string{}
 	for key := range dr {
 		drList = append(drList, key)

--- a/pkg/istio/objects/service_test.go
+++ b/pkg/istio/objects/service_test.go
@@ -1,0 +1,82 @@
+/*
+* [2013] - [2018] Avi Networks Incorporated
+* All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package objects
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+var drLister *DRLister
+
+func TestGetServiceObject(t *testing.T) {
+
+	g := gomega.NewGomegaWithT(t)
+	svcLister := SharedSvcLister()
+	drLister = SharedDRLister()
+	drObj := Make("default", "dr_1", 1)
+	VSObj := MakeVirtualService("default", "vs_1", 1)
+	drLister.DestinationRule("default").Update(drObj)
+	vsVers := vsLister.VirtualService("default").GetAllVSNamesVers()
+	// Obtaining all the VS's in the default namespace
+	vsList := []string{}
+	for key := range vsVers {
+		vsList = append(vsList, key)
+	}
+	dr := drLister.DestinationRule("default").GetAllDRNameVers()
+	// Obtaining all the DR's in the default namespace
+	drList := []string{}
+	for key := range dr {
+		drList = append(drList, key)
+	}
+
+	svcLister.Service("default").UpdateSvcToDR("reviews", drList)
+	vsLister.VirtualService("default").UpdateSvcVSRefs(VSObj)
+	drLister.DestinationRule("default").UpdateDRToSVCMapping("dr_1", "reviews")
+	// Obtaining the services associated with the Virtual Service vs_1
+	svc_obj := vsLister.VirtualService("default").GetVSToSVC("vs_1")
+
+	// Obtaining all the Services associated with the DR List
+	svc_obj1 := []string{}
+	for _, val := range drList {
+		_, svcName := drLister.DestinationRule("default").GetSvcForDR(val)
+		svc_obj1 = append(svc_obj1, svcName)
+	}
+
+	// Both the VS and DR must contain the Service "reviews"
+	g.Expect(svc_obj).To(gomega.ContainElement("reviews"))
+	g.Expect(svc_obj1).To(gomega.ContainElement("reviews"))
+}
+
+func TestGetAllSvcs(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	// Obtaining all the services associated with the VS vs_1
+	svcs1 := vsLister.VirtualService("default").GetVSToSVC("vs_1")
+	svcs2 := []string{}
+	dr := drLister.DestinationRule("default").GetAllDRNameVers()
+	drList := []string{}
+	for key := range dr {
+		drList = append(drList, key)
+	}
+
+	// Obtaining all the services associated with the DR's in the default namespace
+	for _, val := range drList {
+		_, svcName := drLister.DestinationRule("default").GetSvcForDR(val)
+		svcs2 = append(svcs2, svcName)
+	}
+	// Since there are 2 services associated with the VS and only 1 associated with the DR, the service associated with the DR must be present in the services associated with the VS vs_1
+	g.Expect(svcs1).To(gomega.ContainElement(svcs2[0]))
+}

--- a/pkg/istio/objects/service_test.go
+++ b/pkg/istio/objects/service_test.go
@@ -31,13 +31,13 @@ func TestGetServiceObject(t *testing.T) {
 	VSObj := MakeVirtualService("default", "vs_1", 1)
 	drLister.DestinationRule("default").Update(drObj)
 	vsVers := vsLister.VirtualService("default").GetAllVSNamesVers()
-	// Obtaining all the VS's in the default namespace
+	// Obtaining all the VS objects in the default namespace
 	vsList := []string{}
 	for key := range vsVers {
 		vsList = append(vsList, key)
 	}
 	dr := drLister.DestinationRule("default").GetAllDRNameVers()
-	// Obtaining all the DR's in the default namespace
+	// Obtaining all the DR objects in the default namespace
 	drList := []string{}
 	for key := range dr {
 		drList = append(drList, key)


### PR DESCRIPTION
I've written a few test cases for the Istio_model_rel.go file and the avi_model_nodes.go file.
The drain_test.go file is for the Istio_model_rel.go file. 
Changes Made to the drain_test.go file:
- Added additional lines of code to the TestVSServiceCreate() method to add another gateway object.
- Added additional lines of code to the TestVSServiceDelete() method to accommodate for the added gateway object.
- Added a method to test the VSToGateway() method. This method tests the VSToGateway() method by obtaining an array of the gateways and compares it to an array of gateways obtained from the GetGatewaysForVS() method.
- Added a method to test the GetGatewayNamespace() method. This method checks to see if the namespaces for the associated gateways belongs to the default namespace or not.
- Added a method to test the SVCToGateway() method. This method tests the SVCToGateway() method by obtaining an array of gateways and compares it to an array of gateways obtained through the GetGatewaysforVS() method after iterating through the VS's for each of the services and then comparing the two arrays.
- Added a method to test the EPToGateway() method. Since the Ep's are like services, the same idea that was applied to test the SVCToGateway() method was used.
- Added a method to test the GatewayChanges() method. Modifications were made to a particular gateway object and then tests were run on it to make sure the method worked.
- Added a method to test the DrToGateway() method.Still have to run a few tests on it and hence the function has been placed in comments.

Changes Made to the avi_model_nodes.go file:
-Made 2 test methods. One to test the checksum method for AviVsNode, AviPoolGroupNode and the AviPoolNode. The other one is to test some of the boundary cases for the match criteria functions.
